### PR TITLE
docs: update readme for postgres setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,18 +64,24 @@ variables provide additional configuration:
   `/tmp/anyvar.dbm`, or `redis:///15` for redis database 15 on
   localhost.
 
-Example for running with REST API:
+Example for running with public SeqRepo REST API with Redis as a data store:
 
 ```
     $ export GA4GH_VRS_DATAPROXY_URI=seqrepo+https://services.genomicmedlab.org/seqrepo
-    $ export ANYVAR_STORAGE_URI=postgres://postgres:postgres@localhost/anyvar_db
+    $ export ANYVAR_STORAGE_URI="redis:///15"
 ```
 
-Example for running with local SeqRepo:
+Example for running with local SeqRepo with Redis as a datastore:
 
 ```
     $ export SEQREPO_DIR=seqrepo+file:///usr/local/share/seqrepo/latest
     $ export ANYVAR_STORAGE_URI="redis:///15"
+```
+
+The above two examples used Redis as the data store. To use a Postgres instance, set `ANYVAR_STORAGE_URI` to the following:
+
+```
+    $ export ANYVAR_STORAGE_URI=postgres://postgres:postgres@localhost/anyvar_db
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ according to the GA4GH Variation Representation standards.
 * [future] Structural Variation/Translocations/Fusions
 
 All types are assigned computed, digest-based identifiers based on the
-underlying data. 
+underlying data.
 
 
 ## Architecture
@@ -67,8 +67,8 @@ variables provide additional configuration:
 Example for running with REST API:
 
 ```
-    $ export GA4GH_VRS_DATAPROXY_URI=https://services.genomicmedlab.org/seqrepo
-    $ export ANYVAR_STORAGE_URI="redis:///15"
+    $ export GA4GH_VRS_DATAPROXY_URI=seqrepo+https://services.genomicmedlab.org/seqrepo
+    $ export ANYVAR_STORAGE_URI=postgres://postgres:postgres@localhost/anyvar_db
 ```
 
 Example for running with local SeqRepo:
@@ -114,7 +114,15 @@ $ docker run --name anyvar_redis -v anyvar_redis_vol:/data -d redis redis-server
 $ python3 -m anyvar.restapi
 ```
 
+### Setting up Postgres
 
+A Postgres-backed *AnyVar* installation may use any Postgres instance, local
+or remote.  The following instructions are for using a docker-based
+Postgres instance.
+
+First, run the commands in (README-pg.md)[src/anyvar/storage/README-pg.md]. This will create and start a local Postgres docker instance.
+
+Next, run the commands in (postgres_init.sql)[src/anyvar/storage/postgres_init.sql]. This will create the `anyvar` user with the appropriate permissions and create the `anyvar_db` database.
 
 ## Deployment
 

--- a/src/anyvar/storage/__init__.py
+++ b/src/anyvar/storage/__init__.py
@@ -52,7 +52,7 @@ def create_storage(uri=None):
         from .redisobjectstore import RedisObjectStore
         storage = RedisObjectStore(redis.Redis.from_url(uri))
 
-    elif parsed_uri.scheme == "postgres":
+    elif parsed_uri.scheme == "postgresql":
         from .postgres import PostgresObjectStore
         storage = PostgresObjectStore(uri)
 

--- a/src/anyvar/storage/pg_utility.py
+++ b/src/anyvar/storage/pg_utility.py
@@ -20,7 +20,7 @@ class PostgresClient:
         url = _parse_url(db_url)
         #if url.schema is None:
          #   raise Exception("No schema name provided in {url}".format(url=url))
-        if url.scheme != "postgres":
+        if url.scheme != "postgresql":
             raise Exception("Only Postgres databases supported for now")
         self.application_name = application_name
         self.pooling = pooling

--- a/src/anyvar/storage/postgres_init.sql
+++ b/src/anyvar/storage/postgres_init.sql
@@ -1,4 +1,3 @@
 CREATE USER anyvar;
 CREATE DATABASE anyvar_db;
 GRANT ALL PRIVILEGES ON DATABASE anyvar_db TO anyvar;
-CREATE TABLE vrs_objects (id BIGINT primary key, vrs_id text, vrs_object jsonb);


### PR DESCRIPTION
Changes the scheme from `postgres` to `postgresql` to follow the connection URIs as mentioned in the (docs)[https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING]