### PR TITLE
Snowflake database storage integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ A Postgres-backed *AnyVar* installation may use any Postgres instance, local
 or remote.  The following instructions are for using a docker-based
 Postgres instance.
 
-First, run the commands in (README-pg.md)[src/anyvar/storage/README-pg.md]. This will create and start a local Postgres docker instance.
+First, run the commands in [README-pg.md](src/anyvar/storage/README-pg.md). This will create and start a local Postgres docker instance.
 
-Next, run the commands in (postgres_init.sql)[src/anyvar/storage/postgres_init.sql]. This will create the `anyvar` user with the appropriate permissions and create the `anyvar` database.
+Next, run the commands in [postgres_init.sql](src/anyvar/storage/postgres_init.sql). This will create the `anyvar` user with the appropriate permissions and create the `anyvar` database.
 
 ### Setting up Snowflake
 A Snowflake-backed *AnyVar* installation may use any Snowflake database schema.
@@ -75,7 +75,7 @@ variable.  For example:
 
     snowflake://my-sf-acct/?database=sf_db_name&schema=sd_schema_name&user=sf_username&password=sf_password
 
-(Snowflake connection parameter reference)[https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-api]
+[Snowflake connection parameter reference](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-api)
     
 When running interactively and connecting to a Snowflake account that utilizes federated authentication or SSO, add
 the parameter `authenticator=externalbrowser`.  Non-interactive execution in a federated authentication or SSO environment

--- a/README.md
+++ b/README.md
@@ -67,6 +67,25 @@ First, run the commands in (README-pg.md)[src/anyvar/storage/README-pg.md]. This
 
 Next, run the commands in (postgres_init.sql)[src/anyvar/storage/postgres_init.sql]. This will create the `anyvar` user with the appropriate permissions and create the `anyvar` database.
 
+### Setting up Snowflake
+A Snowflake-backed *AnyVar* installation may use any Snowflake database schema.
+The Snowflake database and schema must exist prior to starting *AnyVar*.  To point
+*AnyVar* at Snowflake, specify a Snowflake URI in the `ANYVAR_STORAGE_URI` environment
+variable.  For example:
+
+    snowflake://my-sf-acct/?database=sf_db_name&schema=sd_schema_name&user=sf_username&password=sf_password
+
+(Snowflake connection parameter reference)[https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-api]
+    
+When running interactively and connecting to a Snowflake account that utilizes federated authentication or SSO, add
+the parameter `authenticator=externalbrowser`.  Non-interactive execution in a federated authentication or SSO environment
+requires a service account to connect.
+
+Environment variables that can be used to modify Snowflake database integration:
+* `ANYVAR_SNOWFLAKE_STORE_BATCH_LIMIT` - in batch mode, limit VRS object upsert batches to this number; defaults to `100,000`
+* `ANYVAR_SNOWFLAKE_STORE_TABLE_NAME` - the name of the table that stores VRS objects; defaults to `vrs_objects`
+* `ANYVAR_SNOWFLAKE_STORE_MAX_PENDING_BATCHES` - the maximum number of pending batches to allow before blocking; defaults to `50`
+
 ## Deployment
 
 NOTE: The authoritative and sole source for version tags is the
@@ -95,4 +114,5 @@ Use the environment variable `ANYVAR_TEST_STORAGE_URI` to specify the database t
 % export ANYVAR_TEST_STORAGE_URI=postgresql://postgres:postgres@localhost/anyvar_test
 ```
 
-Currently, there is some interdependency between test modules -- namely, tests that rely on reading data from storage assume that the data from `test_variation` has been uploaded. A pytest hook ensures correct test order, but some test modules may not be able to pass when run in isolation.
+Currently, there is some interdependency between test modules -- namely, tests that rely on reading data from storage assume that the data from `test_variation` has been uploaded. A pytest hook ensures correct test order, but some test modules may not be able to pass when run in isolation.  By default, the tests will use a Postgres database
+installation.  To run the tests against a Snowflake database, change the `ANYVAR_TEST_STORAGE_URI` to a Snowflake URI and run the tests.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ Environment variables that can be used to modify Snowflake database integration:
 * `ANYVAR_SNOWFLAKE_STORE_TABLE_NAME` - the name of the table that stores VRS objects; defaults to `vrs_objects`
 * `ANYVAR_SNOWFLAKE_STORE_MAX_PENDING_BATCHES` - the maximum number of pending batches to allow before blocking; defaults to `50`
 
+NOTE: The Snowflake database connector utilizes a background thread to write VRS objects to the database when operating in batch 
+mode (e.g. annotating a VCF file).  Queries and statistics query only against the already committed database state.  Therefore,
+queries issued immediately after a batch operation may not reflect all pending changes.
+
+
 ## Deployment
 
 NOTE: The authoritative and sole source for version tags is the

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ install_requires =
     uvicorn
     ga4gh.vrs[extras] ~= 2.0.0a1
     psycopg[binary]
+    snowflake-connector-python ~= 3.4.1
 
 [options.package_data]
 * =

--- a/src/anyvar/anyvar.py
+++ b/src/anyvar/anyvar.py
@@ -28,6 +28,9 @@ def create_storage(uri: Optional[str] = None) -> _Storage:
 
     * PostgreSQL
     `postgresql://[username]:[password]@[domain]/[database]`
+    * Snowflake
+    `snowflake://[account_identifier].snowflakecomputing.com/?[param=value]&[param=value]...`
+    `snowflake://[account_identifier]/?[param=value]&[param=value]...`
     """
     uri = uri or os.environ.get("ANYVAR_STORAGE_URI", DEFAULT_STORAGE_URI)
 
@@ -37,7 +40,10 @@ def create_storage(uri: Optional[str] = None) -> _Storage:
         from anyvar.storage.postgres import PostgresObjectStore
 
         storage = PostgresObjectStore(uri)  # type: ignore
+    elif parsed_uri.scheme == "snowflake":
+        from anyvar.storage.snowflake import SnowflakeObjectStore
 
+        storage = SnowflakeObjectStore(uri)
     else:
         raise ValueError(f"URI scheme {parsed_uri.scheme} is not implemented")
 

--- a/src/anyvar/storage/postgres.py
+++ b/src/anyvar/storage/postgres.py
@@ -209,12 +209,17 @@ class PostgresObjectStore(_Storage):
 
     def __iter__(self):
         with self.conn.cursor() as cur:
-            return cur.stream("SELECT * FROM vrs_objects;")
+            cur.execute("SELECT * FROM vrs_objects;")
+            while True:
+                _next = cur.fetchone()
+                if _next is None:
+                    break
+                yield _next
 
     def keys(self):
         with self.conn.cursor() as cur:
             cur.execute("SELECT vrs_id FROM vrs_objects;")
-            result = cur.fetchall()
+            result = [row[0] for row in cur.fetchall()]
         return result
 
     def search_variations(self, refget_accession: str, start: int, stop: int):

--- a/src/anyvar/storage/snowflake.py
+++ b/src/anyvar/storage/snowflake.py
@@ -1,0 +1,467 @@
+import json
+import logging
+import os
+from threading import Condition, Thread
+from typing import Any, List, Optional, Tuple
+from urllib.parse import urlparse, parse_qs
+
+import ga4gh.core
+from ga4gh.vrs import models
+import snowflake.connector
+from snowflake.connector import SnowflakeConnection
+
+from anyvar.restapi.schema import VariationStatisticType
+
+from . import _BatchManager, _Storage
+
+_logger = logging.getLogger(__name__)
+
+
+class SnowflakeObjectStore(_Storage):
+    """Snowflake storage backend. Requires existing Snowflake database."""
+
+    def __init__(self, db_url: str, batch_limit: int = None, table_name: str = None, max_pending_batches: int = None):
+        """Initialize Snowflake DB handler.
+
+        :param db_url: snowflake connection info URL, snowflake://[account_identifier]/?[param=value]&[param=value]...
+        :param batch_limit: max size of batch insert queue, defaults to 100000; can be set with 
+            ANYVAR_SNOWFLAKE_STORE_BATCH_LIMIT environment variable
+        :param table_name: table name for storing VRS objects, defaults to `vrs_objects`; can be set with
+            ANYVAR_SNOWFLAKE_STORE_TABLE_NAME environment variable
+        :param max_pending_batches: maximum number of pending batches allowed before batch queueing blocks; can
+            be set with ANYVAR_SNOWFLAKE_STORE_MAX_PENDING_BATCHES environment variable
+
+        See https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-api for full list
+            of database connection url parameters
+        """
+        # specify that bind variables in queries should be indicated with a question mark
+        snowflake.connector.paramstyle = "qmark"
+
+        # get table name override from environment
+        self.table_name = table_name or str(
+            os.environ.get("ANYVAR_SNOWFLAKE_STORE_TABLE_NAME", "vrs_objects")
+        )
+
+        # parse the db url and extract the account name and conn params
+        parsed_uri = urlparse(db_url)
+        account_name = parsed_uri.hostname.replace(".snowflakecomputing.com", "")
+        conn_params = {
+            key: value[0] if value else None for key, value in parse_qs(parsed_uri.query).items()
+        }
+
+        # log sanitized connection parameters
+        if _logger.isEnabledFor(logging.DEBUG):
+            sanitized_conn_params = conn_params.copy()
+            for secret_param in ["password", "private_key"]:
+                if secret_param in sanitized_conn_params:
+                    sanitized_conn_params[secret_param] = "****sanitized****"
+
+            _logger.debug(
+                "Connecting to Snowflake account %s with params %s",
+                account_name,
+                sanitized_conn_params,
+            )
+        # log connection attempt
+        else:
+            _logger.info(
+                "Connecting to Snowflake account %s",
+                account_name,
+            )
+
+        
+        # create the database connection and ensure it is setup
+        self.conn = snowflake.connector.connect(account=account_name, **conn_params)
+        self.ensure_schema_exists()
+
+        # setup batch handling
+        self.batch_manager = SnowflakeBatchManager
+        self.batch_mode = False
+        self.batch_insert_values = []
+        self.batch_limit = batch_limit or int(
+            os.environ.get("ANYVAR_SNOWFLAKE_STORE_BATCH_LIMIT", "100000")
+        )
+        max_pending_batches = max_pending_batches or int(
+            os.environ.get("ANYVAR_SNOWFLAKE_STORE_MAX_PENDING_BATCHES", "50")
+        )
+        self.batch_thread = SnowflakeBatchThread(self.conn, self.table_name, max_pending_batches)
+        self.batch_thread.start()
+
+    def _create_schema(self):
+        """Add the VRS object table if it does not exist"""
+        create_statement = f"""
+        CREATE TABLE {self.table_name} (
+            vrs_id VARCHAR(500) PRIMARY KEY,
+            vrs_object VARIANT
+        );
+        """
+        _logger.info("Creating VRS object table %s", self.table_name)
+        with self.conn.cursor() as cur:
+            cur.execute(create_statement)
+
+    def ensure_schema_exists(self):
+        """Check that VRS object table exists and create it if it does not"""
+        with self.conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT COUNT(*) FROM information_schema.tables 
+                 WHERE table_catalog = CURRENT_DATABASE() AND table_schema = CURRENT_SCHEMA() 
+                 AND UPPER(table_name) = UPPER('{self.table_name}');
+                """
+            )
+            result = cur.fetchone()
+
+        if result is None or result[0] <= 0:
+            self._create_schema()
+
+    def __repr__(self):
+        return str(self.conn)
+
+    def __setitem__(self, name: str, value: Any):
+        """Add item to database. If batch mode is on, add item to batch and submit batch
+        for write only if batch size is exceeded.
+
+        :param name: value for `vrs_id` field
+        :param value: value for `vrs_object` field
+        """
+        assert ga4gh.core.is_pydantic_instance(value), "ga4gh.vrs object value required"
+        name = str(name)  # in case str-like
+        if self.batch_mode:
+            self.batch_insert_values.append((name, value))
+            if (_logger.isEnabledFor(logging.DEBUG)):
+                _logger.debug("Appended item %s to batch queue", name)
+            if len(self.batch_insert_values) >= self.batch_limit:
+                self.batch_thread.queue_batch(self.batch_insert_values)
+                _logger.info("Queued batch of %s VRS objects for write", len(self.batch_insert_values))
+                self.batch_insert_values = []
+        else:
+            value_json = json.dumps(value.model_dump(exclude_none=True))
+            insert_query = f"""
+                MERGE INTO {self.table_name} t USING (SELECT ? AS vrs_id, ? AS vrs_object) s ON t.vrs_id = s.vrs_id
+                WHEN NOT MATCHED THEN INSERT (vrs_id, vrs_object) VALUES (s.vrs_id, PARSE_JSON(s.vrs_object));
+                """
+            with self.conn.cursor() as cur:
+                cur.execute(insert_query, [name, value_json])
+            if (_logger.isEnabledFor(logging.DEBUG)):
+                _logger.debug("Inserted item %s to %s", name, self.table_name)
+
+    def __getitem__(self, name: str) -> Optional[Any]:
+        """Fetch item from DB given key.
+
+        Future issues:
+         * Remove reliance on VRS-Python models (requires rewriting the enderef module)
+
+        :param name: key to retrieve VRS object for
+        :return: VRS object if available
+        :raise NotImplementedError: if unsupported VRS object type (this is WIP)
+        """
+        with self.conn.cursor() as cur:
+            cur.execute(f"SELECT vrs_object FROM {self.table_name} WHERE vrs_id = ?;", [name])
+            result = cur.fetchone()
+        if result:
+            result = json.loads(result[0])
+            object_type = result["type"]
+            if object_type == "Allele":
+                return models.Allele(**result)
+            elif object_type == "CopyNumberCount":
+                return models.CopyNumberCount(**result)
+            elif object_type == "CopyNumberChange":
+                return models.CopyNumberChange(**result)
+            elif object_type == "SequenceLocation":
+                return models.SequenceLocation(**result)
+            else:
+                raise NotImplementedError
+
+    def __contains__(self, name: str) -> bool:
+        """Check whether VRS objects table contains ID.
+
+        :param name: VRS ID to look up
+        :return: True if ID is contained in vrs objects table
+        """
+        with self.conn.cursor() as cur:
+            cur.execute(f"SELECT COUNT(*) FROM {self.table_name} WHERE vrs_id = ?;", [name])
+            result = cur.fetchone()
+        return result[0] > 0 if result else False
+
+    def __delitem__(self, name: str) -> None:
+        """Delete item (not cascading -- doesn't delete referenced items)
+
+        :param name: key to delete object for
+        """
+        name = str(name)  # in case str-like
+        with self.conn.cursor() as cur:
+            cur.execute(f"DELETE FROM {self.table_name} WHERE vrs_id = ?;", [name])
+        self.conn.commit()
+
+    def close(self):
+        """Stop the batch thread and wait for it to complete"""
+        if self.batch_thread is not None:
+            self.batch_thread.stop()
+            self.batch_thread.join()
+            self.batch_thread = None
+        """Terminate connection if necessary."""
+        if self.conn is not None:
+            self.conn.close()
+            self.conn = None
+
+    def __del__(self):
+        """Tear down DB instance."""
+        self.close()
+
+    def __len__(self):
+        with self.conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT COUNT(*) AS c FROM {self.table_name}
+                WHERE vrs_object:type = 'Allele';
+                """
+            )
+            result = cur.fetchone()
+        if result:
+            return result[0]
+        else:
+            return 0
+
+    def get_variation_count(self, variation_type: VariationStatisticType) -> int:
+        """Get total # of registered variations of requested type.
+
+        :param variation_type: variation type to check
+        :return: total count
+        """
+        if variation_type == VariationStatisticType.SUBSTITUTION:
+            return self._substitution_count()
+        elif variation_type == VariationStatisticType.INSERTION:
+            return self._insertion_count()
+        elif variation_type == VariationStatisticType.DELETION:
+            return self._deletion_count()
+        else:
+            return self._substitution_count() + self._deletion_count() + self._insertion_count()
+
+    def _deletion_count(self) -> int:
+        with self.conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT COUNT(*) FROM {self.table_name}
+                 WHERE LENGTH(vrs_object:state:sequence) = 0;
+                """
+            )
+            result = cur.fetchone()
+        if result:
+            return result[0]
+        else:
+            return 0
+
+    def _substitution_count(self) -> int:
+        with self.conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT COUNT(*) FROM {self.table_name}
+                 WHERE LENGTH(vrs_object:state:sequence) = 1;
+                """
+            )
+            result = cur.fetchone()
+        if result:
+            return result[0]
+        else:
+            return 0
+
+    def _insertion_count(self):
+        with self.conn.cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT COUNT(*) FROM {self.table_name}
+                 WHERE LENGTH(vrs_object:state:sequence) > 1
+                """
+            )
+            result = cur.fetchone()
+        if result:
+            return result[0]
+        else:
+            return 0
+
+    def __iter__(self):
+        with self.conn.cursor() as cur:
+            cur.execute(f"SELECT * FROM {self.table_name};")
+            while True:
+                _next = cur.fetchone()
+                if _next is None:
+                    break
+                yield _next
+
+    def keys(self):
+        with self.conn.cursor() as cur:
+            cur.execute(f"SELECT vrs_id FROM {self.table_name};")
+            result = [row[0] for row in cur.fetchall()]
+        return result
+
+    def search_variations(self, refget_accession: str, start: int, stop: int):
+        """Find all alleles that were registered that are in 1 genomic region
+
+        Args:
+            refget_accession (str): refget accession (SQ. identifier)
+            start (int): Start genomic region to query
+            stop (iint): Stop genomic region to query
+
+        Returns:
+            A list of VRS Alleles that have locations referenced as identifiers
+        """
+        query_str = f"""
+            SELECT vrs_object FROM {self.table_name}
+            WHERE vrs_object:location IN (
+                SELECT vrs_id FROM {self.table_name}
+                WHERE vrs_object:start::INTEGER >= ?
+                AND vrs_object:end::INTEGER <= ?
+                AND vrs_object:sequenceReference:refgetAccession = ?
+            );
+            """
+        with self.conn.cursor() as cur:
+            cur.execute(query_str, [start, stop, refget_accession])
+            results = cur.fetchall()
+        return [json.loads(vrs_object[0]) for vrs_object in results if vrs_object]
+
+    def wipe_db(self):
+        """Remove all stored records from {self.table_name} table."""
+        with self.conn.cursor() as cur:
+            cur.execute(f"DELETE FROM {self.table_name};")
+
+    def num_pending_batches(self):
+        if self.batch_thread:
+            return len(self.batch_thread.pending_batch_list)
+        else:
+            return 0
+
+
+class SnowflakeBatchManager(_BatchManager):
+    """Context manager enabling bulk insertion statements
+
+    Use in cases like VCF ingest when intaking large amounts of data at once.
+    Insertion batches are processed by a background thread.
+    """
+
+    def __init__(self, storage: SnowflakeObjectStore):
+        """Initialize context manager.
+
+        :param storage: Snowflake instance to manage. Should be taken from the active
+        AnyVar instance -- otherwise it won't be able to delay insertions.
+        :raise ValueError: if `storage` param is not a `SnowflakeObjectStore` instance
+        """
+        if not isinstance(storage, SnowflakeObjectStore):
+            raise ValueError("SnowflakeBatchManager requires a SnowflakeObjectStore instance")
+        self._storage = storage
+
+    def __enter__(self):
+        """Enter managed context."""
+        self._storage.batch_insert_values = []
+        self._storage.batch_mode = True
+
+    def __exit__(
+        self, exc_type: Optional[type], exc_value: Optional[BaseException], traceback: Optional[Any]
+    ) -> bool:
+        """Handle exit from context management.  Hands off final batch to background bulk insert processor.
+
+        :param exc_type: type of exception encountered, if any
+        :param exc_value: exception value
+        :param traceback: traceback for context of exception
+        :return: True if no exceptions encountered, False otherwise
+        """
+        if exc_type is not None:
+            self._storage.batch_insert_values = None
+            self._storage.batch_mode = False
+            _logger.error(f"Snowflake batch manager encountered exception {exc_type}: {exc_value}")
+            _logger.exception(exc_value)
+            return False
+        self._storage.batch_thread.queue_batch(self._storage.batch_insert_values)
+        self._storage.batch_mode = False
+        self._storage.batch_insert_values = None
+        return True
+
+
+class SnowflakeBatchThread(Thread):
+    """Background thread that merges VRS objects into the database"""
+
+    def __init__(self, conn: SnowflakeConnection, table_name: str, max_pending_batches: int):
+        """Constructs a new background thread
+
+        :param conn: Snowflake connection
+        """
+        super().__init__(daemon=True)
+        self.conn = conn
+        self.cond = Condition()
+        self.run_flag = True
+        self.pending_batch_list = []
+        self.table_name = table_name
+        self.max_pending_batches = max_pending_batches
+
+    def run(self):
+        """As long as run_flag is true, waits then processes pending batches"""
+        while self.run_flag:
+            with self.cond:
+                self.cond.wait()
+            self.process_pending_batches()
+
+    def stop(self):
+        """Sets the run_flag to false and notifies"""
+        self.run_flag = False
+        with self.cond:
+            self.cond.notify()
+
+    def queue_batch(self, batch_insert_values: List[Tuple]):
+        """Adds a batch to the pending list.  If the pending batch list is already at its max size, waits until there is room
+
+        :param batch_insert_values: list of tuples where each tuple consists of (vrs_id, vrs_object)
+        """
+        with self.cond:
+            if batch_insert_values:
+                _logger.info("Queueing batch of %s items", len(batch_insert_values))
+                while len(self.pending_batch_list) >= self.max_pending_batches:
+                    _logger.debug("Pending batch queue is full, waiting for space...")
+                    self.cond.wait()
+                self.pending_batch_list.append(batch_insert_values)
+                _logger.info("Queued batch of %s items", len(batch_insert_values))
+            self.cond.notify_all()
+
+    def process_pending_batches(self):
+        """As long as batches are available for processing, merges them into the database"""
+        _logger.info("Processing %s queued batches", len(self.pending_batch_list))
+        while True:
+            batch_insert_values = None
+            with self.cond:
+                if len(self.pending_batch_list) > 0:
+                    batch_insert_values = self.pending_batch_list[0]
+                    del self.pending_batch_list[0]
+                    self.cond.notify_all()
+                else:
+                    self.cond.notify_all()
+                    break
+
+            if batch_insert_values:
+                self._run_copy_insert(batch_insert_values)
+                _logger.info("Processed queued batch of %s items", len(batch_insert_values))
+
+    def _run_copy_insert(self, batch_insert_values):
+        """Bulk inserts the batch values into a TEMP table, then merges into the main {self.table_name} table"""
+
+        try:
+            tmp_statement = "CREATE TEMP TABLE IF NOT EXISTS tmp_vrs_objects (vrs_id VARCHAR(500), vrs_object VARCHAR);"
+            insert_statement = "INSERT INTO tmp_vrs_objects (vrs_id, vrs_object) VALUES (?, ?);"
+            merge_statement = f"""
+                MERGE INTO {self.table_name} v USING tmp_vrs_objects s ON v.vrs_id = s.vrs_id 
+                WHEN NOT MATCHED THEN INSERT (vrs_id, vrs_object) VALUES (s.vrs_id, PARSE_JSON(s.vrs_object));
+                """
+            drop_statement = "DROP TABLE tmp_vrs_objects;"
+
+            row_data = [
+                (name, json.dumps(value.model_dump(exclude_none=True)))
+                for name, value in batch_insert_values
+            ]
+            _logger.info("Created row data for insert, first item is %s", row_data[0])
+
+            with self.conn.cursor() as cur:
+                cur.execute(tmp_statement)
+                cur.executemany(insert_statement, row_data)
+                cur.execute(merge_statement)
+                cur.execute(drop_statement)
+            self.conn.commit()
+        except:
+            _logger.exception("Failed to merge VRS object batch into database")
+        finally:
+            self.conn.rollback()

--- a/src/anyvar/storage/snowflake.py
+++ b/src/anyvar/storage/snowflake.py
@@ -23,9 +23,9 @@ class SnowflakeObjectStore(_Storage):
     def __init__(
         self,
         db_url: str,
-        batch_limit: int = None,
-        table_name: str = None,
-        max_pending_batches: int = None,
+        batch_limit: Optional[int] = None,
+        table_name: Optional[str] = None,
+        max_pending_batches: Optional[int] = None,
     ):
         """Initialize Snowflake DB handler.
 
@@ -44,9 +44,7 @@ class SnowflakeObjectStore(_Storage):
         snowflake.connector.paramstyle = "qmark"
 
         # get table name override from environment
-        self.table_name = table_name or str(
-            os.environ.get("ANYVAR_SNOWFLAKE_STORE_TABLE_NAME", "vrs_objects")
-        )
+        self.table_name = table_name or os.environ.get("ANYVAR_SNOWFLAKE_STORE_TABLE_NAME", "vrs_objects")  # noqa: E501
 
         # parse the db url and extract the account name and conn params
         parsed_uri = urlparse(db_url)
@@ -210,7 +208,7 @@ class SnowflakeObjectStore(_Storage):
             self.batch_thread.stop()
             self.batch_thread.join()
             self.batch_thread = None
-        """Terminate connection if necessary."""
+        # Terminate connection if necessary.
         if self.conn is not None:
             self.conn.close()
             self.conn = None

--- a/src/anyvar/storage/snowflake.py
+++ b/src/anyvar/storage/snowflake.py
@@ -99,7 +99,7 @@ class SnowflakeObjectStore(_Storage):
             vrs_id VARCHAR(500) PRIMARY KEY,
             vrs_object VARIANT
         );
-        """ #nosec B608
+        """  # nosec B608
         _logger.info("Creating VRS object table %s", self.table_name)
         with self.conn.cursor() as cur:
             cur.execute(create_statement)
@@ -112,7 +112,7 @@ class SnowflakeObjectStore(_Storage):
                 SELECT COUNT(*) FROM information_schema.tables 
                  WHERE table_catalog = CURRENT_DATABASE() AND table_schema = CURRENT_SCHEMA() 
                  AND UPPER(table_name) = UPPER('{self.table_name}');
-                """ #nosec B608
+                """  # nosec B608
             )
             result = cur.fetchone()
 
@@ -146,7 +146,7 @@ class SnowflakeObjectStore(_Storage):
             insert_query = f"""
                 MERGE INTO {self.table_name} t USING (SELECT ? AS vrs_id, ? AS vrs_object) s ON t.vrs_id = s.vrs_id
                 WHEN NOT MATCHED THEN INSERT (vrs_id, vrs_object) VALUES (s.vrs_id, PARSE_JSON(s.vrs_object));
-                """ #nosec B608
+                """  # nosec B608
             with self.conn.cursor() as cur:
                 cur.execute(insert_query, [name, value_json])
             if _logger.isEnabledFor(logging.DEBUG):
@@ -163,7 +163,9 @@ class SnowflakeObjectStore(_Storage):
         :raise NotImplementedError: if unsupported VRS object type (this is WIP)
         """
         with self.conn.cursor() as cur:
-            cur.execute(f"SELECT vrs_object FROM {self.table_name} WHERE vrs_id = ?;", [name]) #nosec B608
+            cur.execute(
+                f"SELECT vrs_object FROM {self.table_name} WHERE vrs_id = ?;", [name]
+            )  # nosec B608
             result = cur.fetchone()
         if result:
             result = json.loads(result[0])
@@ -186,7 +188,9 @@ class SnowflakeObjectStore(_Storage):
         :return: True if ID is contained in vrs objects table
         """
         with self.conn.cursor() as cur:
-            cur.execute(f"SELECT COUNT(*) FROM {self.table_name} WHERE vrs_id = ?;", [name]) #nosec B608
+            cur.execute(
+                f"SELECT COUNT(*) FROM {self.table_name} WHERE vrs_id = ?;", [name]
+            )  # nosec B608
             result = cur.fetchone()
         return result[0] > 0 if result else False
 
@@ -197,7 +201,7 @@ class SnowflakeObjectStore(_Storage):
         """
         name = str(name)  # in case str-like
         with self.conn.cursor() as cur:
-            cur.execute(f"DELETE FROM {self.table_name} WHERE vrs_id = ?;", [name]) #nosec B608
+            cur.execute(f"DELETE FROM {self.table_name} WHERE vrs_id = ?;", [name])  # nosec B608
         self.conn.commit()
 
     def close(self):
@@ -221,7 +225,7 @@ class SnowflakeObjectStore(_Storage):
                 f"""
                 SELECT COUNT(*) AS c FROM {self.table_name}
                 WHERE vrs_object:type = 'Allele';
-                """ #nosec B608
+                """  # nosec B608
             )
             result = cur.fetchone()
         if result:
@@ -250,7 +254,7 @@ class SnowflakeObjectStore(_Storage):
                 f"""
                 SELECT COUNT(*) FROM {self.table_name}
                  WHERE LENGTH(vrs_object:state:sequence) = 0;
-                """ #nosec B608
+                """  # nosec B608
             )
             result = cur.fetchone()
         if result:
@@ -264,7 +268,7 @@ class SnowflakeObjectStore(_Storage):
                 f"""
                 SELECT COUNT(*) FROM {self.table_name}
                  WHERE LENGTH(vrs_object:state:sequence) = 1;
-                """ #nosec B608
+                """  # nosec B608
             )
             result = cur.fetchone()
         if result:
@@ -278,7 +282,7 @@ class SnowflakeObjectStore(_Storage):
                 f"""
                 SELECT COUNT(*) FROM {self.table_name}
                  WHERE LENGTH(vrs_object:state:sequence) > 1
-                """ #nosec B608
+                """  # nosec B608
             )
             result = cur.fetchone()
         if result:
@@ -288,7 +292,7 @@ class SnowflakeObjectStore(_Storage):
 
     def __iter__(self):
         with self.conn.cursor() as cur:
-            cur.execute(f"SELECT * FROM {self.table_name};") #nosec B608
+            cur.execute(f"SELECT * FROM {self.table_name};")  # nosec B608
             while True:
                 _next = cur.fetchone()
                 if _next is None:
@@ -297,7 +301,7 @@ class SnowflakeObjectStore(_Storage):
 
     def keys(self):
         with self.conn.cursor() as cur:
-            cur.execute(f"SELECT vrs_id FROM {self.table_name};") #nosec B608
+            cur.execute(f"SELECT vrs_id FROM {self.table_name};")  # nosec B608
             result = [row[0] for row in cur.fetchall()]
         return result
 
@@ -320,7 +324,7 @@ class SnowflakeObjectStore(_Storage):
                 AND vrs_object:end::INTEGER <= ?
                 AND vrs_object:sequenceReference:refgetAccession = ?
             );
-            """ #nosec B608
+            """  # nosec B608
         with self.conn.cursor() as cur:
             cur.execute(query_str, [start, stop, refget_accession])
             results = cur.fetchall()
@@ -329,7 +333,7 @@ class SnowflakeObjectStore(_Storage):
     def wipe_db(self):
         """Remove all stored records from {self.table_name} table."""
         with self.conn.cursor() as cur:
-            cur.execute(f"DELETE FROM {self.table_name};") #nosec B608
+            cur.execute(f"DELETE FROM {self.table_name};")  # nosec B608
 
     def num_pending_batches(self):
         if self.batch_thread:
@@ -454,7 +458,7 @@ class SnowflakeBatchThread(Thread):
             merge_statement = f"""
                 MERGE INTO {self.table_name} v USING tmp_vrs_objects s ON v.vrs_id = s.vrs_id 
                 WHEN NOT MATCHED THEN INSERT (vrs_id, vrs_object) VALUES (s.vrs_id, PARSE_JSON(s.vrs_object));
-                """ #nosec B608
+                """  # nosec B608
             drop_statement = "DROP TABLE tmp_vrs_objects;"
 
             row_data = [

--- a/src/anyvar/storage/snowflake.py
+++ b/src/anyvar/storage/snowflake.py
@@ -46,7 +46,7 @@ class SnowflakeObjectStore(_Storage):
         # get table name override from environment
         self.table_name = table_name or os.environ.get(
             "ANYVAR_SNOWFLAKE_STORE_TABLE_NAME", "vrs_objects"
-        )  # noqa: E501
+        )
 
         # parse the db url and extract the account name and conn params
         parsed_uri = urlparse(db_url)

--- a/src/anyvar/storage/snowflake.py
+++ b/src/anyvar/storage/snowflake.py
@@ -461,7 +461,7 @@ class SnowflakeBatchThread(Thread):
                 cur.execute(merge_statement)
                 cur.execute(drop_statement)
             self.conn.commit()
-        except:
+        except Exception:
             _logger.exception("Failed to merge VRS object batch into database")
         finally:
             self.conn.rollback()

--- a/src/anyvar/storage/snowflake.py
+++ b/src/anyvar/storage/snowflake.py
@@ -44,7 +44,9 @@ class SnowflakeObjectStore(_Storage):
         snowflake.connector.paramstyle = "qmark"
 
         # get table name override from environment
-        self.table_name = table_name or os.environ.get("ANYVAR_SNOWFLAKE_STORE_TABLE_NAME", "vrs_objects")  # noqa: E501
+        self.table_name = table_name or os.environ.get(
+            "ANYVAR_SNOWFLAKE_STORE_TABLE_NAME", "vrs_objects"
+        )  # noqa: E501
 
         # parse the db url and extract the account name and conn params
         parsed_uri = urlparse(db_url)

--- a/src/anyvar/storage/snowflake.py
+++ b/src/anyvar/storage/snowflake.py
@@ -164,8 +164,8 @@ class SnowflakeObjectStore(_Storage):
         """
         with self.conn.cursor() as cur:
             cur.execute(
-                f"SELECT vrs_object FROM {self.table_name} WHERE vrs_id = ?;", [name]
-            )  # nosec B608
+                f"SELECT vrs_object FROM {self.table_name} WHERE vrs_id = ?;", [name]  # nosec B608
+            )
             result = cur.fetchone()
         if result:
             result = json.loads(result[0])
@@ -189,8 +189,8 @@ class SnowflakeObjectStore(_Storage):
         """
         with self.conn.cursor() as cur:
             cur.execute(
-                f"SELECT COUNT(*) FROM {self.table_name} WHERE vrs_id = ?;", [name]
-            )  # nosec B608
+                f"SELECT COUNT(*) FROM {self.table_name} WHERE vrs_id = ?;", [name]  # nosec B608
+            )
             result = cur.fetchone()
         return result[0] > 0 if result else False
 

--- a/src/anyvar/storage/snowflake.py
+++ b/src/anyvar/storage/snowflake.py
@@ -131,8 +131,7 @@ class SnowflakeObjectStore(_Storage):
         name = str(name)  # in case str-like
         if self.batch_mode:
             self.batch_insert_values.append((name, value))
-            if _logger.isEnabledFor(logging.DEBUG):
-                _logger.debug("Appended item %s to batch queue", name)
+            _logger.debug("Appended item %s to batch queue", name)
             if len(self.batch_insert_values) >= self.batch_limit:
                 self.batch_thread.queue_batch(self.batch_insert_values)
                 _logger.info(
@@ -147,8 +146,7 @@ class SnowflakeObjectStore(_Storage):
                 """  # nosec B608
             with self.conn.cursor() as cur:
                 cur.execute(insert_query, [name, value_json])
-            if _logger.isEnabledFor(logging.DEBUG):
-                _logger.debug("Inserted item %s to %s", name, self.table_name)
+            _logger.debug("Inserted item %s to %s", name, self.table_name)
 
     def __getitem__(self, name: str) -> Optional[Any]:
         """Fetch item from DB given key.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,14 +12,13 @@ from anyvar.restapi.main import app as anyvar_restapi
 
 def pytest_collection_modifyitems(items):
     """Modify test items in place to ensure test modules run in a given order."""
-    MODULE_ORDER = ["test_variation", "test_general", "test_location", "test_search", "test_vcf"]
+    MODULE_ORDER = ["test_variation", "test_general", "test_location", "test_search", "test_vcf", "test_storage_mapping", "test_snowflake"]
     # remember to add new test modules to the order constant:
     assert len(MODULE_ORDER) == len(list(Path(__file__).parent.rglob("test_*.py")))
     items.sort(key=lambda i: MODULE_ORDER.index(i.module.__name__))
 
-
 @pytest.fixture(scope="session")
-def client():
+def storage():
     """Provide API client instance as test fixture"""
     if "ANYVAR_TEST_STORAGE_URI" in os.environ:
         storage_uri = os.environ["ANYVAR_TEST_STORAGE_URI"]
@@ -28,6 +27,10 @@ def client():
 
     storage = create_storage(uri=storage_uri)
     storage.wipe_db()
+    return storage
+
+@pytest.fixture(scope="session")
+def client(storage):
     translator = create_translator()
     anyvar_restapi.state.anyvar = AnyVar(object_store=storage, translator=translator)
     return TestClient(app=anyvar_restapi)

--- a/tests/storage/test_snowflake.py
+++ b/tests/storage/test_snowflake.py
@@ -1,0 +1,228 @@
+"""
+Test Snowflake storage async batch management and write feature
+
+To run an integration test with a real Snowflake connection, run all
+  the tests with the ANYVAR_TEST_STORAGE_URI env variable set to 
+  a Snowflake URI
+"""
+import json
+import logging
+import re
+import time
+
+from anyvar.storage.snowflake import SnowflakeObjectStore
+
+class MockStmt:
+    def __init__(self, sql: str, params: list, result: list, wait_for_secs: int = 0):
+        self.sql = re.sub(r'\s+', ' ', sql).strip()
+        self.params = params
+        self.result = result
+        self.wait_for_secs = wait_for_secs
+
+    def matches(self, sql: str, params: list):
+        norm_sql = re.sub(r'\s+', ' ', sql).strip()
+        if norm_sql == self.sql:
+            if self.params == True:
+                return True
+            elif (self.params is None or len(self.params) == 0) and (params is None or len(params) == 0):
+                return True
+            elif self.params == params:
+                return True
+        return False
+
+class MockStmtSequence(list):
+    def __init__(self):
+        self.execd = []
+
+    def add_stmt(self, sql: str, params: list, result: list, wait_for_secs: int = 0):
+        self.append(MockStmt(sql, params, result, wait_for_secs))
+        return self
+
+    def pop_if_matches(self, sql: str, params: list) -> list:
+        if len(self) > 0 and self[0].matches(sql, params):
+            self.execd.append(self[0])
+            wait_for_secs = self[0].wait_for_secs
+            result = self[0].result
+            del self[0]
+            if wait_for_secs > 0:
+                time.sleep(wait_for_secs)
+            if isinstance(result, Exception):
+                raise result
+            else:
+                return result
+        return None
+    
+    def were_all_execd(self):
+        return len(self) <= 0
+
+class MockConnectionCursor:
+    def __init__(self):
+        self.mock_stmt_sequences = []
+        self.current_result = None
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+    def cursor(self):
+        if self.closed:
+            raise Exception("connection is closed")
+        return self
+    
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> bool:
+        if exc_value:
+            raise exc_value
+        return True
+
+    def execute(self, cmd: str, params: list = None):
+        if self.closed:
+            raise Exception("connection is closed")
+        self.current_result = None
+        for seq in self.mock_stmt_sequences:
+            result = seq.pop_if_matches(cmd, params)
+            if result:
+                self.current_result = result
+        if not self.current_result:
+            raise Exception(f"no mock statement found for {cmd} with params {params}")
+
+    def executemany(self, cmd: str, params: list = None):
+        self.execute(cmd, params)
+
+    def fetchone(self):
+        if self.closed:
+            raise Exception("connection is closed")
+        return self.current_result[0] if self.current_result and len(self.current_result) > 0 else None
+    
+    def commit(self):
+        self.execute("COMMIT;", None)
+
+    def rollback(self):
+        self.execute("ROLLBACK;", None)
+
+    def add_mock_stmt_sequence(self, stmt_seq: MockStmtSequence):
+        self.mock_stmt_sequences.append(stmt_seq)
+    
+    def were_all_execd(self):
+        for seq in self.mock_stmt_sequences:
+            if not seq.were_all_execd():
+                return False
+        return True
+
+class MockVRSObject:
+    def __init__(self, id: str):
+        self.id = id
+
+    def model_dump(self, exclude_none: bool):
+        return { "id": self.id }
+    
+    def to_json(self):
+        return json.dumps(self.model_dump(exclude_none=True))
+
+def test_create_schema(caplog, mocker):
+    caplog.set_level(logging.DEBUG)
+    sf_conn = mocker.patch('snowflake.connector.connect')
+    sf_conn.return_value = MockConnectionCursor()
+    sf_conn.return_value.add_mock_stmt_sequence(MockStmtSequence()
+        .add_stmt("SELECT COUNT(*) FROM information_schema.tables WHERE table_catalog = CURRENT_DATABASE() AND table_schema = CURRENT_SCHEMA() AND UPPER(table_name) = UPPER('vrs_objects');", None, [(0,)])
+        .add_stmt("CREATE TABLE vrs_objects ( vrs_id VARCHAR(500) PRIMARY KEY, vrs_object VARIANT );", None, [("Table created",)])
+    )
+
+    sf = SnowflakeObjectStore("snowflake://account/?param=value")
+    sf.close()
+    assert sf_conn.return_value.were_all_execd()
+
+
+def test_schema_exists(mocker):
+    sf_conn = mocker.patch('snowflake.connector.connect')
+    sf_conn.return_value = MockConnectionCursor()
+    sf_conn.return_value.add_mock_stmt_sequence(MockStmtSequence()
+        .add_stmt("SELECT COUNT(*) FROM information_schema.tables WHERE table_catalog = CURRENT_DATABASE() AND table_schema = CURRENT_SCHEMA() AND UPPER(table_name) = UPPER('vrs_objects');", None, [(1,)])
+    )
+
+    sf = SnowflakeObjectStore("snowflake://account/?param=value")
+    sf.close()
+    assert sf_conn.return_value.were_all_execd()
+
+
+def test_batch_mgmt_and_async_write_single_thread(mocker):
+    tmp_statement = "CREATE TEMP TABLE IF NOT EXISTS tmp_vrs_objects (vrs_id VARCHAR(500), vrs_object VARCHAR);"
+    insert_statement = "INSERT INTO tmp_vrs_objects (vrs_id, vrs_object) VALUES (?, ?);"
+    merge_statement = f"""
+        MERGE INTO vrs_objects2 v USING tmp_vrs_objects s ON v.vrs_id = s.vrs_id 
+        WHEN NOT MATCHED THEN INSERT (vrs_id, vrs_object) VALUES (s.vrs_id, PARSE_JSON(s.vrs_object));
+        """
+    drop_statement = "DROP TABLE tmp_vrs_objects;"
+
+    vrs_id_object_pairs = [
+        ("ga4gh:VA.01", MockVRSObject('01')),
+        ("ga4gh:VA.02", MockVRSObject('02')),
+        ("ga4gh:VA.03", MockVRSObject('03')),
+        ("ga4gh:VA.04", MockVRSObject('04')),
+        ("ga4gh:VA.05", MockVRSObject('05')),
+        ("ga4gh:VA.06", MockVRSObject('06')),
+        ("ga4gh:VA.07", MockVRSObject('07')),
+        ("ga4gh:VA.08", MockVRSObject('08')),
+        ("ga4gh:VA.09", MockVRSObject('09')),
+        ("ga4gh:VA.10", MockVRSObject('10')),
+        ("ga4gh:VA.11", MockVRSObject('11')),
+    ]
+
+    mocker.patch('ga4gh.core.is_pydantic_instance', return_value=True)
+    sf_conn = mocker.patch('snowflake.connector.connect')
+    sf_conn.return_value = MockConnectionCursor()
+    sf_conn.return_value.add_mock_stmt_sequence(MockStmtSequence()
+        .add_stmt("SELECT COUNT(*) FROM information_schema.tables WHERE table_catalog = CURRENT_DATABASE() AND table_schema = CURRENT_SCHEMA() AND UPPER(table_name) = UPPER('vrs_objects2');", None, [(1,)])
+        # Batch 1
+        .add_stmt(tmp_statement, None, [("Table created",)])
+        .add_stmt(insert_statement, list((pair[0], pair[1].to_json()) for pair in vrs_id_object_pairs[0:2]), [(2,)], 5)
+        .add_stmt(merge_statement, None, [(2,)])
+        .add_stmt(drop_statement, None, [("Table dropped",)])
+        .add_stmt("COMMIT;", None, [("Committed", )])
+        .add_stmt("ROLLBACK;", None, [("Rolled back", )])
+        # Batch 2
+        .add_stmt(tmp_statement, None, [("Table created",)])
+        .add_stmt(insert_statement, list((pair[0], pair[1].to_json()) for pair in vrs_id_object_pairs[2:4]), [(2,)], 4)
+        .add_stmt(merge_statement, None, [(2,)])
+        .add_stmt(drop_statement, None, [("Table dropped",)])
+        .add_stmt("COMMIT;", None, [("Committed", )])
+        .add_stmt("ROLLBACK;", None, [("Rolled back", )])
+        # Batch 3
+        .add_stmt(tmp_statement, None, [("Table created",)])
+        .add_stmt(insert_statement, list((pair[0], pair[1].to_json()) for pair in vrs_id_object_pairs[4:6]), [(2,)], 3)
+        .add_stmt(merge_statement, None, [(2,)])
+        .add_stmt(drop_statement, None, [("Table dropped",)])
+        .add_stmt("COMMIT;", None, [("Committed", )])
+        .add_stmt("ROLLBACK;", None, [("Rolled back", )])
+        # Batch 4
+        .add_stmt(tmp_statement, None, [("Table created",)])
+        .add_stmt(insert_statement, list((pair[0], pair[1].to_json()) for pair in vrs_id_object_pairs[6:8]), [(2,)], 5)
+        .add_stmt(merge_statement, None, [(2,)])
+        .add_stmt(drop_statement, None, [("Table dropped",)])
+        .add_stmt("COMMIT;", None, [("Committed", )])
+        .add_stmt("ROLLBACK;", None, [("Rolled back", )])
+        # Batch 5
+        .add_stmt(tmp_statement, None, [("Table created",)])
+        .add_stmt(insert_statement, list((pair[0], pair[1].to_json()) for pair in vrs_id_object_pairs[8:10]), [(2,)], 3)
+        .add_stmt(merge_statement, None, Exception("query timeout"))
+        .add_stmt("ROLLBACK;", None, [("Rolled back", )])
+        # Batch 6
+        .add_stmt(tmp_statement, None, [("Table created",)])
+        .add_stmt(insert_statement, list((pair[0], pair[1].to_json()) for pair in vrs_id_object_pairs[10:11]), [(2,)], 2)
+        .add_stmt(merge_statement, None, [(2,)])
+        .add_stmt(drop_statement, None, [("Table dropped",)])
+        .add_stmt("COMMIT;", None, [("Committed", )])
+        .add_stmt("ROLLBACK;", None, [("Rolled back", )])
+    )
+
+    sf = SnowflakeObjectStore("snowflake://account/?param=value", 2, "vrs_objects2", 4)
+    with sf.batch_manager(sf):
+        for vo in vrs_id_object_pairs:
+            sf[vo[0]] = vo[1]
+
+    assert sf.num_pending_batches() > 0
+    sf.close()
+    assert sf.num_pending_batches() == 0
+    assert sf_conn.return_value.were_all_execd()

--- a/tests/storage/test_storage_mapping.py
+++ b/tests/storage/test_storage_mapping.py
@@ -1,0 +1,55 @@
+"""Tests the mutable mapping API of the storage backend"""
+from ga4gh.vrs import vrs_enref
+
+from anyvar.translate.vrs_python import VrsPythonTranslator
+
+# pause for 5 seconds because Snowflake storage is an async write and
+#   tests will sometimes fail on test_storage_mapping
+def test_waitforsync():
+    import time
+    time.sleep(5)
+
+# __getitem__
+def test_getitem(storage, alleles):
+    for allele_id, allele in alleles.items():
+        assert storage[allele_id] is not None
+
+# __contains__
+def test_contains(storage, alleles):
+    for allele_id, allele in alleles.items():
+        assert allele_id in storage
+
+# __len__
+def test_len(storage):
+    assert len(storage) > 0
+
+# __iter__
+def test_iter(storage, alleles):
+    obj_iter = iter(storage)
+    count = 0
+    while True:
+        try:
+            obj = next(obj_iter)
+            count += 1
+        except StopIteration:
+            break
+    assert count == 11
+
+# keys
+def test_keys(storage, alleles):
+    key_list = storage.keys()
+    for allele_id, allele in alleles.items():
+        assert allele_id in key_list
+        
+# __delitem__
+def test_delitem(storage, alleles):
+    for allele_id, allele in alleles.items():
+        del storage[allele_id]
+
+# __setitem__
+def test_setitem(storage, alleles):
+    for allele_id, allele in alleles.items():
+        variation = allele["params"]
+        definition = variation["definition"]
+        translated_variation = VrsPythonTranslator().translate_variation(definition)
+        vrs_enref(translated_variation, storage)


### PR DESCRIPTION
Added an implementation of `anyvar.storage._Storage` that connects to a Snowflake database.

To facilitate processing whole genome VCF files without waits for database writes, the storage integration uses a background thread with queueing to write VRS object batches to the database.  There is one background thread created for each instance of the `SnowflakeObjectStore`, which in turn has one instance per HTTP worker.

Unit tests for the `MutableMapping` API (`tests/storage/test_storage_mapping.py`) and specific to the background thread behavior (`tests/storage/test_snowflake.py`) have been added.  The unit tests now cover the full storage API for both Postgres and Snowflake, though multiple runs with different `ANYVAR_TEST_STORAGE_URI` settings are required.  Bugs identified in the Postgres API by the new unit tests were also fixed.

Test coverage using a Snowflake storage URI with debug logging enabled is as follows:
```
---------- coverage: platform darwin, python 3.11.6-final-0 ----------
Name                                 Stmts   Miss Branch BrPart  Cover   Missing
--------------------------------------------------------------------------------
src/anyvar/__init__.py                  23      3      4      1    85%   10->21, 17-18, 26
src/anyvar/anyvar.py                    41      6      6      3    81%   40-42, 48, 74, 87-88
src/anyvar/extras/vcf.py                29      6     10      4    74%   49, 85-86, 91-92, 94->exit, 98
src/anyvar/restapi/__init__.py           0      0      0      0   100%
src/anyvar/restapi/main.py             120     26     40      6    79%   45-48, 89-90, 127-128, 135, 180-181, 214-219, 246-247, 282-283, 288->298, 292-293, 299->306, 303, 332-333
src/anyvar/restapi/schema.py            70     15     18      0    69%   39-43, 89-93, 134-138
src/anyvar/storage/__init__.py          16      0      8      0   100%
src/anyvar/storage/postgres.py         160    160     74      0     0%   1-324
src/anyvar/storage/snowflake.py        240     15    107     15    91%   63, 72, 136->138, 152->exit, 234, 243, 245, 247, 263, 277, 291, 360, 379-383, 425->432, 448->437
src/anyvar/translate/__init__.py         1      0      0      0   100%
src/anyvar/translate/translate.py       17      0     10      0   100%
src/anyvar/translate/vrs_python.py      45      1      6      2    94%   36->41, 63
src/anyvar/utils/__init__.py             0      0      0      0   100%
src/anyvar/utils/types.py               10      0      0      0   100%
--------------------------------------------------------------------------------
TOTAL                                  772    232    283     31    67%
```

See also #64 and the README for documentation.