### PR TITLE
Improve performance of AnyVar.put_object() by eliminating unnecessary digest computation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ install_requires =
     fastapi >= 0.95.0
     python-multipart
     uvicorn
-    ga4gh.vrs[extras] ~= 2.0.0a1
+    ga4gh.vrs[extras] ~= 2.0.0a2
     psycopg[binary]
     snowflake-connector-python ~= 3.4.1
 

--- a/src/anyvar/anyvar.py
+++ b/src/anyvar/anyvar.py
@@ -82,7 +82,7 @@ class AnyVar:
         :return: Object digest if successful, None otherwise
         """
         try:
-            id, v = vrs_enref(variation_object, self.object_store, True)
+            id, _ = vrs_enref(variation_object, self.object_store, True)
         except ValueError:
             return None
         return id

--- a/src/anyvar/anyvar.py
+++ b/src/anyvar/anyvar.py
@@ -9,7 +9,6 @@ from collections.abc import MutableMapping
 from typing import Optional
 from urllib.parse import urlparse
 
-from ga4gh.core import ga4gh_identify
 from ga4gh.vrs import vrs_deref, vrs_enref
 
 from anyvar.storage import DEFAULT_STORAGE_URI, _Storage

--- a/src/anyvar/anyvar.py
+++ b/src/anyvar/anyvar.py
@@ -83,10 +83,10 @@ class AnyVar:
         :return: Object digest if successful, None otherwise
         """
         try:
-            v = vrs_enref(variation_object, self.object_store)
+            id, v = vrs_enref(variation_object, self.object_store, True)
         except ValueError:
             return None
-        return ga4gh_identify(v)
+        return id
 
     def get_object(self, object_id: str, deref: bool = False) -> Optional[VrsObject]:
         """Retrieve registered variation.


### PR DESCRIPTION
In `AnyVar.put_object()`, use new parameter to `vrs_enref()` method to return both the object and identifier.  This eliminates the need to recompute the already computed digest and improve performance.

See also #71 