### PR TITLE
Add parameter to /vcf endpoint to force async writes to complete before returning response

### DIFF
--- a/src/anyvar/restapi/main.py
+++ b/src/anyvar/restapi/main.py
@@ -194,8 +194,11 @@ def register_vrs_object(
     tags=[EndpointTag.VARIATIONS],
 )
 async def annotate_vcf(
-    request: Request, vcf: UploadFile = File(..., description="VCF to register and annotate"),
-    allow_async_write: bool = Query(default=False, description="Whether to allow asynchronous write of VRS objects to database"),
+    request: Request,
+    vcf: UploadFile = File(..., description="VCF to register and annotate"),
+    allow_async_write: bool = Query(
+        default=False, description="Whether to allow asynchronous write of VRS objects to database"
+    ),
 ):
     """Register alleles from a VCF and return a file annotated with VRS IDs.
 

--- a/src/anyvar/storage/__init__.py
+++ b/src/anyvar/storage/__init__.py
@@ -37,7 +37,7 @@ class _Storage(MutableMapping):
 
     @abstractmethod
     def wait_for_writes(self):
-        """Return true once any currently pending database modifications have been completed."""
+        """Returns once any currently pending database modifications have been completed."""
 
 
 class _BatchManager(AbstractContextManager):

--- a/src/anyvar/storage/__init__.py
+++ b/src/anyvar/storage/__init__.py
@@ -35,6 +35,10 @@ class _Storage(MutableMapping):
     def wipe_db(self):
         """Empty database of all stored records."""
 
+    @abstractmethod
+    def wait_for_writes(self):
+        """Return true once any currently pending database modifications have been completed."""
+
 
 class _BatchManager(AbstractContextManager):
     """Base context management class for batch writing.

--- a/src/anyvar/storage/__init__.py
+++ b/src/anyvar/storage/__init__.py
@@ -44,7 +44,6 @@ class _Storage(MutableMapping):
         """Closes the storage integration and cleans up any resources"""
 
 
-
 class _BatchManager(AbstractContextManager):
     """Base context management class for batch writing.
 

--- a/src/anyvar/storage/postgres.py
+++ b/src/anyvar/storage/postgres.py
@@ -127,6 +127,10 @@ class PostgresObjectStore(_Storage):
             cur.execute("DELETE FROM vrs_objects WHERE vrs_id = %s;", [name])
         self.conn.commit()
 
+    def wait_for_writes(self):
+        """Return true once any currently pending database modifications have been completed."""
+        pass
+
     def close(self):
         """Terminate connection if necessary."""
         if self.conn is not None:

--- a/src/anyvar/storage/postgres.py
+++ b/src/anyvar/storage/postgres.py
@@ -128,8 +128,9 @@ class PostgresObjectStore(_Storage):
         self.conn.commit()
 
     def wait_for_writes(self):
-        """Return true once any currently pending database modifications have been completed."""
-        pass
+        """Returns once any currently pending database modifications have been completed.
+        The PostgresObjectStore does not implement async writes, therefore this method is a no-op
+        and present only to maintain compatibility with the `_Storage` base class"""
 
     def close(self):
         """Terminate connection if necessary."""

--- a/src/anyvar/storage/snowflake.py
+++ b/src/anyvar/storage/snowflake.py
@@ -207,7 +207,7 @@ class SnowflakeObjectStore(_Storage):
         if self.batch_thread is not None:
             # short circuit if the queue is empty
             with self.batch_thread.cond:
-                if len(self.batch_thread.pending_batch_list) == 0:
+                if not self.batch_thread.pending_batch_list:
                     return
 
             # queue an empty batch
@@ -216,12 +216,7 @@ class SnowflakeObjectStore(_Storage):
             # wait for the batch to be removed from the pending queue
             while True:
                 with self.batch_thread.cond:
-                    if (
-                        len(
-                            list(filter(lambda x: x is batch, self.batch_thread.pending_batch_list))
-                        )
-                        > 0
-                    ):
+                    if list(filter(lambda x: x is batch, self.batch_thread.pending_batch_list)):
                         self.batch_thread.cond.wait()
                     else:
                         break

--- a/src/anyvar/storage/snowflake.py
+++ b/src/anyvar/storage/snowflake.py
@@ -203,7 +203,7 @@ class SnowflakeObjectStore(_Storage):
         self.conn.commit()
 
     def wait_for_writes(self):
-        """Return true once any currently pending database modifications have been completed."""
+        """Returns once any currently pending database modifications have been completed."""
         if self.batch_thread is not None:
             # short circuit if the queue is empty
             with self.batch_thread.cond:

--- a/src/anyvar/storage/snowflake.py
+++ b/src/anyvar/storage/snowflake.py
@@ -202,6 +202,27 @@ class SnowflakeObjectStore(_Storage):
             cur.execute(f"DELETE FROM {self.table_name} WHERE vrs_id = ?;", [name])  # nosec B608
         self.conn.commit()
 
+    def wait_for_writes(self):
+        """Return true once any currently pending database modifications have been completed."""
+        if self.batch_thread is not None:
+
+            # short circuit if the queue is empty
+            with self.batch_thread.cond:
+                if len(self.batch_thread.pending_batch_list) == 0:
+                    return
+
+            # queue an empty batch
+            batch = []
+            self.batch_thread.queue_batch(batch)
+            # wait for the batch to be removed from the pending queue
+            while True:
+                with self.batch_thread.cond:
+                    if len(list(filter(lambda x: x is batch, self.batch_thread.pending_batch_list))) > 0:
+                        self.batch_thread.cond.wait()
+                    else:
+                        break
+
+
     def close(self):
         """Stop the batch thread and wait for it to complete"""
         if self.batch_thread is not None:
@@ -420,7 +441,7 @@ class SnowflakeBatchThread(Thread):
         :param batch_insert_values: list of tuples where each tuple consists of (vrs_id, vrs_object)
         """
         with self.cond:
-            if batch_insert_values:
+            if batch_insert_values is not None:
                 _logger.info("Queueing batch of %s items", len(batch_insert_values))
                 while len(self.pending_batch_list) >= self.max_pending_batches:
                     _logger.debug("Pending batch queue is full, waiting for space...")

--- a/src/anyvar/storage/snowflake.py
+++ b/src/anyvar/storage/snowflake.py
@@ -205,7 +205,6 @@ class SnowflakeObjectStore(_Storage):
     def wait_for_writes(self):
         """Return true once any currently pending database modifications have been completed."""
         if self.batch_thread is not None:
-
             # short circuit if the queue is empty
             with self.batch_thread.cond:
                 if len(self.batch_thread.pending_batch_list) == 0:
@@ -217,11 +216,15 @@ class SnowflakeObjectStore(_Storage):
             # wait for the batch to be removed from the pending queue
             while True:
                 with self.batch_thread.cond:
-                    if len(list(filter(lambda x: x is batch, self.batch_thread.pending_batch_list))) > 0:
+                    if (
+                        len(
+                            list(filter(lambda x: x is batch, self.batch_thread.pending_batch_list))
+                        )
+                        > 0
+                    ):
                         self.batch_thread.cond.wait()
                     else:
                         break
-
 
     def close(self):
         """Stop the batch thread and wait for it to complete"""

--- a/tests/storage/test_snowflake.py
+++ b/tests/storage/test_snowflake.py
@@ -219,8 +219,22 @@ def test_batch_mgmt_and_async_write_single_thread(mocker):
 
     sf = SnowflakeObjectStore("snowflake://account/?param=value", 2, "vrs_objects2", 4)
     with sf.batch_manager(sf):
-        for vo in vrs_id_object_pairs:
-            sf[vo[0]] = vo[1]
+        sf.wait_for_writes()
+        assert sf.num_pending_batches() == 0
+        sf[vrs_id_object_pairs[0][0]] = vrs_id_object_pairs[0][1]
+        sf[vrs_id_object_pairs[1][0]] = vrs_id_object_pairs[1][1]
+        assert sf.num_pending_batches() > 0
+        sf.wait_for_writes()
+        assert sf.num_pending_batches() == 0
+        sf[vrs_id_object_pairs[2][0]] = vrs_id_object_pairs[2][1]
+        sf[vrs_id_object_pairs[3][0]] = vrs_id_object_pairs[3][1]
+        sf[vrs_id_object_pairs[4][0]] = vrs_id_object_pairs[4][1]
+        sf[vrs_id_object_pairs[5][0]] = vrs_id_object_pairs[5][1]
+        sf[vrs_id_object_pairs[6][0]] = vrs_id_object_pairs[6][1]
+        sf[vrs_id_object_pairs[7][0]] = vrs_id_object_pairs[7][1]
+        sf[vrs_id_object_pairs[8][0]] = vrs_id_object_pairs[8][1]
+        sf[vrs_id_object_pairs[9][0]] = vrs_id_object_pairs[9][1]
+        sf[vrs_id_object_pairs[10][0]] = vrs_id_object_pairs[10][1]
 
     assert sf.num_pending_batches() > 0
     sf.close()


### PR DESCRIPTION
The new Snowflake object store writes VRS objects to the database asynchronously to allow better response times.  However, since searches and fetches only read committed database state, this creates the opportunity for reads to not reflect the most recent VRS objects.

The current default behavior, and default behavior moving forward, is for all writes to complete before the response is returned to the client.  To enable writes to complete asynchronously after the response has been returned, clients can add the `allow_async_writes=yes` parameter to the request.

See also #65