### PR TITLE
Cleanup storage integration and write pending batches on shutdown

### DIFF
--- a/src/anyvar/storage/__init__.py
+++ b/src/anyvar/storage/__init__.py
@@ -35,6 +35,10 @@ class _Storage(MutableMapping):
     def wipe_db(self):
         """Empty database of all stored records."""
 
+    @abstractmethod
+    def close(self):
+        """Closes the storage integration and cleans up any resources"""
+
 
 class _BatchManager(AbstractContextManager):
     """Base context management class for batch writing.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from anyvar.restapi.main import app as anyvar_restapi
 
 def pytest_collection_modifyitems(items):
     """Modify test items in place to ensure test modules run in a given order."""
-    MODULE_ORDER = ["test_variation", "test_general", "test_location", "test_search", "test_vcf", "test_storage_mapping", "test_snowflake"]
+    MODULE_ORDER = ["test_lifespan", "test_variation", "test_general", "test_location", "test_search", "test_vcf", "test_storage_mapping", "test_snowflake"]
     # remember to add new test modules to the order constant:
     assert len(MODULE_ORDER) == len(list(Path(__file__).parent.rglob("test_*.py")))
     items.sort(key=lambda i: MODULE_ORDER.index(i.module.__name__))

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -1,0 +1,26 @@
+from fastapi.testclient import TestClient
+from fastapi import FastAPI
+from anyvar.restapi.main import app_lifespan
+from anyvar.storage import _Storage
+
+
+def test_lifespan(mocker):
+    """Test the app_lifespan method in anyvar.restapi.main"""
+    create_storage_mock = mocker.patch("anyvar.anyvar.create_storage")
+    storage_mock = mocker.Mock(spec=_Storage)
+    create_storage_mock.return_value = storage_mock
+    create_translator_mock = mocker.patch("anyvar.anyvar.create_translator")
+    create_translator_mock.return_value = {}
+    app = FastAPI(
+        title="AnyVarTest",
+        docs_url="/",
+        openapi_url="/openapi.json",
+        description="Test app",
+        lifespan=app_lifespan,
+    )
+    with TestClient(app) as client:
+        create_storage_mock.assert_called_once()
+        create_translator_mock.assert_called_once()
+        assert app.state.anyvar is not None
+
+    storage_mock.close.assert_called_once()


### PR DESCRIPTION
The integration used by AnyVar to store, retrieve and query VRS objects should be provided an opportunity to complete pending work, shutdown and clean up when an AnyVar worker is shutdown.  The FastAPI provides lifespan events that can be used for this purpose.

The changes simply make the `close()` method part of the `_Storage` API definition and then call the method when the shutdown occurs.  Implementations of the `close()` already existed for both the PostgreSQL and Snowflake storage implementations.

The existing startup event handler was moved to a new lifespan method and the call to `close()` added to the lifespan method.  Event handlers have been deprecated in favor of [lifespan](https://fastapi.tiangolo.com/advanced/events/).

See also #66