### PR TITLE
Add support for GRCh37 to /vcf endpoint

### DIFF
--- a/src/anyvar/extras/vcf.py
+++ b/src/anyvar/extras/vcf.py
@@ -73,8 +73,7 @@ class VcfRegistrar(VCFAnnotator):
         :param vrs_data: Dictionary containing the VRS object information for the VCF
         :param vrs_field_data: If `output_vcf`, will keys will be VRS Fields and values
             will be list of VRS data. Else, will be an empty dictionary.
-        :param assembly: The assembly used in `vcf_coords`. Not used by this
-            implementation -- GRCh38 is assumed.
+        :param assembly: The assembly used in `vcf_coords`
         :param vrs_data_key: The key to update in `vrs_data`. If not provided, will use
             `vcf_coords` as the key.
         :param output_pickle: `True` if VRS pickle file will be output. `False`
@@ -86,7 +85,7 @@ class VcfRegistrar(VCFAnnotator):
             Only used if `vcf_out` is provided. Not used by this implementation.
         :return: nothing, but registers VRS objects with AnyVar storage and stashes IDs
         """
-        vrs_object = self.av.translator.translate_vcf_row(vcf_coords)
+        vrs_object = self.av.translator.translate_vcf_row(assembly, vcf_coords)
         if vrs_object:
             self.av.put_object(vrs_object)
             if output_pickle:
@@ -99,5 +98,5 @@ class VcfRegistrar(VCFAnnotator):
 
         else:
             raise TranslationException(
-                f"Translator returned empty VRS object for VCF coords {vcf_coords}"
+                f"Translator returned empty VRS object for VCF coords {assembly} {vcf_coords}"
             )

--- a/src/anyvar/restapi/main.py
+++ b/src/anyvar/restapi/main.py
@@ -212,6 +212,11 @@ async def annotate_vcf(
     allow_async_write: bool = Query(
         default=False, description="Whether to allow asynchronous write of VRS objects to database"
     ),
+    assembly: str = Query(
+        default="GRCh38",
+        pattern="^(GRCh38|GRCh37)$",
+        description="The reference assembly for the VCF",
+    ),
 ):
     """Register alleles from a VCF and return a file annotated with VRS IDs.
 
@@ -219,6 +224,7 @@ async def annotate_vcf(
     :param vcf: incoming VCF file object
     :param for_ref: whether to compute VRS IDs for REF alleles
     :param allow_async_write: whether to allow async database writes
+    :param assembly: the reference assembly for the VCF
     :return: streamed annotated file
     """
     with tempfile.NamedTemporaryFile(delete=False) as temp_file:
@@ -230,7 +236,10 @@ async def annotate_vcf(
         with tempfile.NamedTemporaryFile(delete=False) as temp_out_file:
             try:
                 registrar.annotate(
-                    temp_file.name, vcf_out=temp_out_file.name, compute_for_ref=for_ref
+                    temp_file.name,
+                    vcf_out=temp_out_file.name,
+                    compute_for_ref=for_ref,
+                    assembly=assembly,
                 )
             except (TranslatorConnectionException, OSError) as e:
                 _logger.error(f"Encountered error during VCF registration: {e}")

--- a/src/anyvar/translate/translate.py
+++ b/src/anyvar/translate/translate.py
@@ -62,10 +62,11 @@ class _Translator(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def translate_vcf_row(self, coords: str) -> Optional[VrsVariation]:
+    def translate_vcf_row(self, assembly: str, coords: str) -> Optional[VrsVariation]:
         """Translate VCF-like data to a normalized VRS object.
 
         :param coords: string formatted a la "<chr>-<pos>-<ref>-<alt>"
+        :param assembly: The assembly used in `coords`
         :return: VRS variation (using VRS-Python class) if translation is successful
         """
         raise NotImplementedError

--- a/src/anyvar/translate/vrs_python.py
+++ b/src/anyvar/translate/vrs_python.py
@@ -113,13 +113,14 @@ class VrsPythonTranslator(_Translator):
         except ValueError:
             raise TranslationException(f"{var} isn't supported by the VRS-Python CnvTranslator.")
 
-    def translate_vcf_row(self, coords: str) -> Optional[VrsVariation]:
+    def translate_vcf_row(self, assembly: str, coords: str) -> Optional[VrsVariation]:
         """Translate VCF-like data to a VRS object.
 
         :param coords: string formatted a la "<chr>-<pos>-<ref>-<alt>"
+        :param assembly: The assembly used in `coords`
         :return: VRS variation (using VRS-Python class) if translation is successful
         """
-        return self.allele_tlr.translate_from(coords, "gnomad")
+        return self.allele_tlr.translate_from(coords, "gnomad", assembly_name=assembly)
 
     def get_sequence_id(self, accession_id: str) -> str:
         """Get GA4GH sequence identifier for provided accession ID

--- a/tests/storage/test_storage_mapping.py
+++ b/tests/storage/test_storage_mapping.py
@@ -33,7 +33,7 @@ def test_iter(storage, alleles):
             count += 1
         except StopIteration:
             break
-    assert count == 11
+    assert count == 14
 
 # keys
 def test_keys(storage, alleles):

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -6,8 +6,8 @@ import pytest
 
 
 @pytest.fixture(scope="function")
-def sample_vcf():
-    """Basic VCF fixture to use in tests."""
+def sample_vcf_grch38():
+    """Basic GRCh38 VCF fixture to use in tests."""
     file_content = b"""##fileformat=VCFv4.2
 ##hailversion=0.2.100-2ea2615a797a
 ##INFO=<ID=QUALapprox,Number=1,Type=Integer,Description="">
@@ -44,12 +44,73 @@ chr1	10330	.	CCCCTAACCCTAACCCTAACCCTACCCTAACCCTAACCCTAACCCTAACCCTAA	C	.	PASS	QUA
     file = io.BytesIO(file_content)
     return file
 
-
-def test_vcf_registration(client, sample_vcf):
-    """Test registration and annotation of VCFs"""
-    resp = client.put("/vcf", files={"vcf": ("test.vcf", sample_vcf)})
+def test_vcf_registration_default_assembly(client, sample_vcf_grch38):
+    """Test registration and annotation of VCFs with default assembly"""
+    resp = client.put("/vcf", files={"vcf": ("test.vcf", sample_vcf_grch38)})
     assert resp.status_code == HTTPStatus.OK
     assert (
         b"VRS_Allele_IDs=ga4gh:VA.8MVWsPFeScEY_19U32k4LVI_3lEOKGUL,ga4gh:VA.l7crC9qxgcDtexejZkfp6yPNevEMnZ5y"
         in resp.content
     )
+
+def test_vcf_registration_grch38(client, sample_vcf_grch38):
+    """Test registration and annotation of VCFs specifying GRCh38 as the assembly to use"""
+    resp = client.put("/vcf", params={"assembly": "GRCh38"}, files={"vcf": ("test.vcf", sample_vcf_grch38)})
+    assert resp.status_code == HTTPStatus.OK
+    assert (
+        b"VRS_Allele_IDs=ga4gh:VA.8MVWsPFeScEY_19U32k4LVI_3lEOKGUL,ga4gh:VA.l7crC9qxgcDtexejZkfp6yPNevEMnZ5y"
+        in resp.content
+    )
+
+@pytest.fixture(scope="function")
+def sample_vcf_grch37():
+    """Basic GRCh37 VCF fixture to use in tests."""
+    file_content = b"""##fileformat=VCFv4.2
+##hailversion=0.2.100-2ea2615a797a
+##INFO=<ID=QUALapprox,Number=1,Type=Integer,Description="">
+##INFO=<ID=SB,Number=.,Type=Integer,Description="">
+##INFO=<ID=MQ,Number=1,Type=Float,Description="">
+##INFO=<ID=MQRankSum,Number=1,Type=Float,Description="">
+##INFO=<ID=VarDP,Number=1,Type=Integer,Description="">
+##INFO=<ID=AS_ReadPosRankSum,Number=1,Type=Float,Description="">
+##INFO=<ID=AS_pab_max,Number=1,Type=Float,Description="">
+##INFO=<ID=AS_QD,Number=1,Type=Float,Description="">
+##INFO=<ID=AS_MQ,Number=1,Type=Float,Description="">
+##INFO=<ID=QD,Number=1,Type=Float,Description="">
+##INFO=<ID=AS_MQRankSum,Number=1,Type=Float,Description="">
+##INFO=<ID=FS,Number=1,Type=Float,Description="">
+##INFO=<ID=AS_FS,Number=1,Type=Float,Description="">
+##INFO=<ID=ReadPosRankSum,Number=1,Type=Float,Description="">
+##INFO=<ID=AS_QUALapprox,Number=1,Type=Integer,Description="">
+##INFO=<ID=AS_SB_TABLE,Number=.,Type=Integer,Description="">
+##INFO=<ID=AS_VarDP,Number=1,Type=Integer,Description="">
+##INFO=<ID=AS_SOR,Number=1,Type=Float,Description="">
+##INFO=<ID=SOR,Number=1,Type=Float,Description="">
+##INFO=<ID=singleton,Number=0,Type=Flag,Description="">
+##INFO=<ID=transmitted_singleton,Number=0,Type=Flag,Description="">
+##INFO=<ID=omni,Number=0,Type=Flag,Description="">
+##INFO=<ID=mills,Number=0,Type=Flag,Description="">
+##INFO=<ID=monoallelic,Number=0,Type=Flag,Description="">
+##INFO=<ID=AS_VQSLOD,Number=1,Type=Float,Description="">
+##INFO=<ID=InbreedingCoeff,Number=1,Type=Float,Description="">
+##FILTER=<ID=AC0,Description="Allele count is zero after filtering out low-confidence genotypes (GQ < 20; DP < 10; and AB < 0.2 for het calls)">
+##FILTER=<ID=AS_VQSR,Description="Failed VQSR filtering thresholds of -2.7739 for SNPs and -1.0606 for indels">
+##contig=<ID=11,length=248956422,assembly=GRCh37>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+11	47352948	.	TGAGAA	CCT	.	PASS	QUALapprox=21493;SB=325,1077,113,694;MQ=32.1327;MQRankSum=0.720000;VarDP=2236;AS_ReadPosRankSum=-0.736000;AS_pab_max=1.00000;AS_QD=5.17857;AS_MQ=29.5449;QD=9.61225;AS_MQRankSum=0.00000;FS=8.55065;AS_FS=.;ReadPosRankSum=0.727000;AS_QUALapprox=145;AS_SB_TABLE=325,1077,2,5;AS_VarDP=28;AS_SOR=0.311749;SOR=1.48100;singleton;AS_VQSLOD=13.4641;InbreedingCoeff=-0.000517845"""
+    file = io.BytesIO(file_content)
+    return file
+
+def test_vcf_registration_grch37(client, sample_vcf_grch37):
+    """Test registration and annotation of VCFs with GRCh37 assembly"""
+    resp = client.put("/vcf", params={"assembly": "GRCh37"}, files={"vcf": ("test.vcf", sample_vcf_grch37)})
+    assert resp.status_code == HTTPStatus.OK
+    assert (
+        b"VRS_Allele_IDs=ga4gh:VA.R-tU3agvAtsRD59MXZaCymsVE4yjMpt3,ga4gh:VA.f_EzEO6CLZmubm1gbL20F9EV8GZPLAJz"
+        in resp.content
+    )
+
+def test_vcf_registration_invalid_assembly(client, sample_vcf_grch37):
+    """Test registration and annotation of VCFs with invalid assembly param value"""
+    resp = client.put("/vcf", params={"assembly": "hg19"}, files={"vcf": ("test.vcf", sample_vcf_grch37)})
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY


### PR DESCRIPTION
Allow caller of the `/vcf` endpoint to specify an `assembly` parameter that can be set to either `GRCh38` (default) or `GRCh37`.  The assembly is passed to through to the vrs-python `AlleleTranslator`.

Alternate assembly names (e.g. hg38) are not supported by this change.

Updated unit tests to include computing VRS IDs for both assemblies and parameter validation.