### PR TITLE
Update VCF annotator code to be compatible with superclass in vrs-python

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ install_requires =
     fastapi>=0.95.0
     python-multipart
     uvicorn
-    ga4gh.vrs[extras]~=2.0.0a2
+    ga4gh.vrs[extras]~=2.0.0a5
     psycopg[binary]
     snowflake-connector-python~=3.4.1
 

--- a/src/anyvar/extras/vcf.py
+++ b/src/anyvar/extras/vcf.py
@@ -65,6 +65,7 @@ class VcfRegistrar(VCFAnnotator):
         output_pickle: bool = True,
         output_vcf: bool = False,
         vrs_attributes: bool = False,
+        require_validation: bool = True,
     ) -> None:
         """Get VRS Object given `vcf_coords`. `vrs_data` and `vrs_field_data` will
         be mutated. Generally, we expect AnyVar to use the output_vcf option rather than
@@ -84,6 +85,10 @@ class VcfRegistrar(VCFAnnotator):
         :param vrs_attributes: If `True` will include VRS_Start, VRS_End, VRS_State
             fields in the INFO field. If `False` will not include these fields.
             Only used if `vcf_out` is provided. Not used by this implementation.
+        :param bool require_validation: If `True` then validation checks must pass in
+            order to return a VRS object. If `False` then VRS object will be returned
+            even if validation checks fail. Defaults to `True`.  Not used by this 
+            implementation.
         :return: nothing, but registers VRS objects with AnyVar storage and stashes IDs
         """
         vrs_object = self.av.translator.translate_vcf_row(assembly, vcf_coords)

--- a/src/anyvar/extras/vcf.py
+++ b/src/anyvar/extras/vcf.py
@@ -87,7 +87,7 @@ class VcfRegistrar(VCFAnnotator):
             Only used if `vcf_out` is provided. Not used by this implementation.
         :param bool require_validation: If `True` then validation checks must pass in
             order to return a VRS object. If `False` then VRS object will be returned
-            even if validation checks fail. Defaults to `True`.  Not used by this 
+            even if validation checks fail. Defaults to `True`.  Not used by this
             implementation.
         :return: nothing, but registers VRS objects with AnyVar storage and stashes IDs
         """


### PR DESCRIPTION
See #84 

The AnyVar VCF annotator that overrides `_get_vrs_object()` ignores the `require_validation` parameter when invoking the translator.  The translator uses the default value `True` and validates the reference sequence.  This is the current behavior of the AnyVar VCF annotator.