### PR TITLE
Snowflake storage integration updates for collation and private key auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,16 @@ variable.  For example:
 
 When running interactively and connecting to a Snowflake account that utilizes federated authentication or SSO, add
 the parameter `authenticator=externalbrowser`.  Non-interactive execution in a federated authentication or SSO environment
-requires a service account to connect.
+requires a service account to connect.  Connections using an encrypted or unencrypted private key are also supported by 
+specifying the parameter `private_key=path/to/file.p8`.  The key material may be URL-encoded and inlined in the connection URI, 
+for example: `private_key=-----BEGIN+PRIVATE+KEY-----%0AMIIEvAIBA...`
+
 
 Environment variables that can be used to modify Snowflake database integration:
 * `ANYVAR_SNOWFLAKE_STORE_BATCH_LIMIT` - in batch mode, limit VRS object upsert batches to this number; defaults to `100,000`
 * `ANYVAR_SNOWFLAKE_STORE_TABLE_NAME` - the name of the table that stores VRS objects; defaults to `vrs_objects`
 * `ANYVAR_SNOWFLAKE_STORE_MAX_PENDING_BATCHES` - the maximum number of pending batches to allow before blocking; defaults to `50`
+* `ANYVAR_SNOWFLAKE_STORE_PRIVATE_KEY_PASSPHRASE` - the passphrase for an encrypted private key
 
 NOTE: If you choose to create the VRS objects table in advance, the minimal table specification is as follows:
 ```sql

--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ Environment variables that can be used to modify Snowflake database integration:
 * `ANYVAR_SNOWFLAKE_STORE_TABLE_NAME` - the name of the table that stores VRS objects; defaults to `vrs_objects`
 * `ANYVAR_SNOWFLAKE_STORE_MAX_PENDING_BATCHES` - the maximum number of pending batches to allow before blocking; defaults to `50`
 
+NOTE: If you choose to create the VRS objects table in advance, the minimal table specification is as follows:
+```sql
+CREATE TABLE ... (
+    vrs_id VARCHAR(500) COLLATE 'utf8',
+    vrs_object VARIANT
+)
+```
+
 NOTE: The Snowflake database connector utilizes a background thread to write VRS objects to the database when operating in batch
 mode (e.g. annotating a VCF file).  Queries and statistics query only against the already committed database state.  Therefore,
 queries issued immediately after a batch operation may not reflect all pending changes.

--- a/src/anyvar/storage/snowflake.py
+++ b/src/anyvar/storage/snowflake.py
@@ -96,7 +96,7 @@ class SnowflakeObjectStore(_Storage):
         # self.table_name is only modifiable via environment variable or direct instantiation of the SnowflakeObjectStore
         create_statement = f"""
         CREATE TABLE {self.table_name} (
-            vrs_id VARCHAR(500) PRIMARY KEY,
+            vrs_id VARCHAR(500) PRIMARY KEY COLLATE 'utf8',
             vrs_object VARIANT
         );
         """  # nosec B608
@@ -470,7 +470,7 @@ class SnowflakeBatchThread(Thread):
         """Bulk inserts the batch values into a TEMP table, then merges into the main {self.table_name} table"""
 
         try:
-            tmp_statement = "CREATE TEMP TABLE IF NOT EXISTS tmp_vrs_objects (vrs_id VARCHAR(500), vrs_object VARCHAR);"
+            tmp_statement = "CREATE TEMP TABLE IF NOT EXISTS tmp_vrs_objects (vrs_id VARCHAR(500) COLLATE 'utf8', vrs_object VARCHAR);"
             insert_statement = "INSERT INTO tmp_vrs_objects (vrs_id, vrs_object) VALUES (?, ?);"
             merge_statement = f"""
                 MERGE INTO {self.table_name} v USING tmp_vrs_objects s ON v.vrs_id = s.vrs_id 

--- a/src/anyvar/storage/snowflake.py
+++ b/src/anyvar/storage/snowflake.py
@@ -5,6 +5,8 @@ from threading import Condition, Thread
 from typing import Any, List, Optional, Tuple
 from urllib.parse import urlparse, parse_qs
 
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
 import ga4gh.core
 from ga4gh.vrs import models
 import snowflake.connector
@@ -54,6 +56,29 @@ class SnowflakeObjectStore(_Storage):
         conn_params = {
             key: value[0] if value else None for key, value in parse_qs(parsed_uri.query).items()
         }
+
+        # if there is a private_key param that is a file, read the contents of file
+        if "private_key" in conn_params:
+            pk_value = conn_params["private_key"]
+            p_key = None
+            pk_passphrase = None
+            if "ANYVAR_SNOWFLAKE_STORE_PRIVATE_KEY_PASSPHRASE" in os.environ:
+                pk_passphrase = os.environ["ANYVAR_SNOWFLAKE_STORE_PRIVATE_KEY_PASSPHRASE"].encode()
+            if os.path.isfile(pk_value):
+                with open(pk_value, "rb") as key:
+                    p_key = serialization.load_pem_private_key(
+                        key.read(), password=pk_passphrase, backend=default_backend()
+                    )
+            else:
+                p_key = serialization.load_pem_private_key(
+                    pk_value.encode(), password=pk_passphrase, backend=default_backend()
+                )
+
+            conn_params["private_key"] = p_key.private_bytes(
+                encoding=serialization.Encoding.DER,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
 
         # log sanitized connection parameters
         if _logger.isEnabledFor(logging.DEBUG):

--- a/tests/storage/test_snowflake.py
+++ b/tests/storage/test_snowflake.py
@@ -127,7 +127,7 @@ def test_create_schema(caplog, mocker):
     sf_conn.return_value = MockConnectionCursor()
     sf_conn.return_value.add_mock_stmt_sequence(MockStmtSequence()
         .add_stmt("SELECT COUNT(*) FROM information_schema.tables WHERE table_catalog = CURRENT_DATABASE() AND table_schema = CURRENT_SCHEMA() AND UPPER(table_name) = UPPER('vrs_objects');", None, [(0,)])
-        .add_stmt("CREATE TABLE vrs_objects ( vrs_id VARCHAR(500) PRIMARY KEY, vrs_object VARIANT );", None, [("Table created",)])
+        .add_stmt("CREATE TABLE vrs_objects ( vrs_id VARCHAR(500) PRIMARY KEY COLLATE 'utf8', vrs_object VARIANT );", None, [("Table created",)])
     )
 
     sf = SnowflakeObjectStore("snowflake://account/?param=value")
@@ -148,7 +148,7 @@ def test_schema_exists(mocker):
 
 
 def test_batch_mgmt_and_async_write_single_thread(mocker):
-    tmp_statement = "CREATE TEMP TABLE IF NOT EXISTS tmp_vrs_objects (vrs_id VARCHAR(500), vrs_object VARCHAR);"
+    tmp_statement = "CREATE TEMP TABLE IF NOT EXISTS tmp_vrs_objects (vrs_id VARCHAR(500) COLLATE 'utf8', vrs_object VARCHAR);"
     insert_statement = "INSERT INTO tmp_vrs_objects (vrs_id, vrs_object) VALUES (?, ?);"
     merge_statement = f"""
         MERGE INTO vrs_objects2 v USING tmp_vrs_objects s ON v.vrs_id = s.vrs_id 


### PR DESCRIPTION
Two updates for Snowflake storage integration.

When creating tables for VRS objects, explicitly set the collation to `utf8` to ensure that VRS ID comparisons are case-sensitive.

Support private key authentication for Snowflake connections.  This is done by adding the `private_key` parameter to the Snowflake connection URI.  The value is a file path or URL-encoded key material.  Examples:
```
...&private_key=path/to/private_key.p8
```
Or
```
...&private_key=-----BEGIN+PRIVATE+KEY-----%0AMIIEvAIBA...
```
If the private key material is encrypted, the `ANYVAR_SNOWFLAKE_STORE_PRIVATE_KEY_PASSPHRASE` environment variable must be set to the decryption password.

See also #88 and #89