### PR TITLE
Fix problems introduced by project configuration changes and dependency upgrades

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "python-multipart",  # required for fastapi file uploads
     "uvicorn",
     "ga4gh.vrs[extras]~=2.0.0a10",
+    "sqlalchemy~=1.4.54",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "fastapi>=0.95.0",
     "python-multipart",  # required for fastapi file uploads
     "uvicorn",
-    "ga4gh.vrs[extras]~=2.0.0a10",
+    "ga4gh.vrs[extras]~=2.0.0a11",
     "sqlalchemy~=1.4.54",
 ]
 dynamic = ["version"]

--- a/src/anyvar/restapi/main.py
+++ b/src/anyvar/restapi/main.py
@@ -216,6 +216,7 @@ def register_vrs_object(
     summary="Register alleles from a VCF",
     description="Provide a valid VCF. All reference and alternate alleles will be registered with AnyVar. The file is annotated with VRS IDs and returned.",
     tags=[EndpointTag.VARIATIONS],
+    response_model=None,
 )
 async def annotate_vcf(
     request: Request,

--- a/src/anyvar/storage/snowflake.py
+++ b/src/anyvar/storage/snowflake.py
@@ -91,7 +91,9 @@ class SnowflakeObjectStore(SqlStorage):
         env_batch_mode_name = os.environ.get(
             "ANYVAR_SNOWFLAKE_BATCH_ADD_MODE", SnowflakeBatchAddMode.merge.name
         )
-        self.batch_add_mode = (batch_add_mode or SnowflakeBatchAddMode[env_batch_mode_name])
+        self.batch_add_mode = (
+            batch_add_mode or SnowflakeBatchAddMode[env_batch_mode_name]
+        )
         if self.batch_add_mode not in SnowflakeBatchAddMode:
             msg = "batch_add_mode must be one of 'merge', 'insert_notin', or 'insert'"
             raise Exception(msg)

--- a/src/anyvar/storage/snowflake.py
+++ b/src/anyvar/storage/snowflake.py
@@ -56,7 +56,7 @@ SnowflakeDialect.create_connect_args = sf_create_connect_args_override
 #
 
 
-class SnowflakeBatchAddMode(str, Enum):
+class SnowflakeBatchAddMode(Enum):
     """Define values for snowflake batch add modes"""
 
     merge = auto()
@@ -88,10 +88,11 @@ class SnowflakeObjectStore(SqlStorage):
             max_pending_batches,
             flush_on_batchctx_exit,
         )
-        self.batch_add_mode = batch_add_mode or os.environ.get(
-            "ANYVAR_SNOWFLAKE_BATCH_ADD_MODE", SnowflakeBatchAddMode.merge
+        env_batch_mode_name = os.environ.get(
+            "ANYVAR_SNOWFLAKE_BATCH_ADD_MODE", SnowflakeBatchAddMode.merge.name
         )
-        if self.batch_add_mode not in SnowflakeBatchAddMode.__members__:
+        self.batch_add_mode = (batch_add_mode or SnowflakeBatchAddMode[env_batch_mode_name])
+        if self.batch_add_mode not in SnowflakeBatchAddMode:
             msg = "batch_add_mode must be one of 'merge', 'insert_notin', or 'insert'"
             raise Exception(msg)
 

--- a/tests/data/variations.json
+++ b/tests/data/variations.json
@@ -63,7 +63,7 @@
     "ga4gh:CX.TvAhuGK6HYf53mXoUnon60cZ7DC_UgM3": {
       "params": {
         "definition": "NC_000013.11:g.26440969_26443305del",
-        "copy_change": "efo:0030069",
+        "copy_change": "EFO:0030069",
         "input_type": "CopyNumberChange"
       },
       "copy_number_response": {
@@ -82,7 +82,7 @@
             },
             "type": "SequenceLocation"
           },
-          "copyChange": "efo:0030069",
+          "copyChange": "EFO:0030069",
           "type": "CopyNumberChange"
         }
       },


### PR DESCRIPTION
The latest round of updates to the project configuration and dependency changes caused some things to break.
- Added sqlalchemy to list of required dependencies (#98)
- Disable FastAPI validation of response model for `/vcf` endpoint since the `FileResponse` is not valid pydantic field (#99)
- Fix handling of batch add mode setting in Snowflake connector (#100)
- Change variant test data to use "EFO:" instead of "efo:" in copy number objects because Pydantic deserialization was failing