### PR TITLE
Convert ANYVAR_SQL_STORE_FLUSH_ON_BATCHCTX_EXIT  env value to boolean explicitly

### DIFF
--- a/src/anyvar/storage/sql_storage.py
+++ b/src/anyvar/storage/sql_storage.py
@@ -75,7 +75,8 @@ class SqlStorage(_Storage):
             os.environ.get("ANYVAR_SQL_STORE_BATCH_LIMIT", "100000")
         )
         self.flush_on_batchctx_exit = (
-            bool(os.environ.get("ANYVAR_SQL_STORE_FLUSH_ON_BATCHCTX_EXIT", "True"))
+            os.environ.get("ANYVAR_SQL_STORE_FLUSH_ON_BATCHCTX_EXIT", "true").lower()
+            in ["true", "yes", "1"]
             if flush_on_batchctx_exit is None
             else flush_on_batchctx_exit
         )


### PR DESCRIPTION
Fix for #103 

Explicitly convert the `ANYVAR_SQL_STORE_FLUSH_ON_BATCHCTX_EXIT` environment variable from a string to a boolean.  Evaluates to `true` if the environment variable is `true`, `yes` or `1`, not case sensitive.