### PR TITLE
Add feature to allow logging configuration to be specified at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,3 +213,44 @@ uploaded. A pytest hook ensures correct test order, but some test modules may no
 able to pass when run in isolation. By default, the tests will use a Postgres database
 installation. To run the tests against a Snowflake database, change the
 `ANYVAR_TEST_STORAGE_URI` to a Snowflake URI and run the tests.
+
+## Logging
+AnyVar uses the [Python Logging Module](https://docs.python.org/3/howto/logging.html) to
+output information and diagnostics.  By default, log output is directed to standard output
+and the level is set to `INFO`.  Alternatively, a YAML logging configuration may be specified
+using the `ANYVAR_LOGGING_CONFIG` environment variable.  The value must be the relative or
+absolute path of a YAML file containing a valid logging configuration. The configuration
+in this file will be loaded and used to configured the logging module.
+
+For example:
+```yaml
+version: 1
+disable_existing_loggers: true
+
+formatters:
+  standard:
+    format: "%(threadName)s %(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+handlers:
+  console:
+    class: logging.StreamHandler
+    level: DEBUG
+    formatter: standard
+    stream: ext://sys.stdout
+
+root:
+  level: INFO
+  handlers: [console]
+  propagate: yes
+
+loggers:
+  anyvar.restapi.main:
+    level: INFO
+    handlers: [console]
+    propagate: no
+
+  anyvar.storage.sql_storage:
+    level: DEBUG
+    handlers: [console]
+    propagate: no
+```

--- a/src/anyvar/storage/sql_storage.py
+++ b/src/anyvar/storage/sql_storage.py
@@ -74,14 +74,22 @@ class SqlStorage(_Storage):
         self.batch_limit = batch_limit or int(
             os.environ.get("ANYVAR_SQL_STORE_BATCH_LIMIT", "100000")
         )
+        _logger.debug("set batch limit to %s", self.batch_limit)
+
         self.flush_on_batchctx_exit = (
             bool(os.environ.get("ANYVAR_SQL_STORE_FLUSH_ON_BATCHCTX_EXIT", "True"))
             if flush_on_batchctx_exit is None
             else flush_on_batchctx_exit
         )
+        _logger.debug(
+            "set flush on batch context exit to %s", self.flush_on_batchctx_exit
+        )
+
         max_pending_batches = max_pending_batches or int(
             os.environ.get("ANYVAR_SQL_STORE_MAX_PENDING_BATCHES", "50")
         )
+        _logger.debug("set max pending batches to %s", max_pending_batches)
+
         self.batch_thread = SqlStorageBatchThread(self, max_pending_batches)
         self.batch_thread.start()
 
@@ -227,6 +235,8 @@ class SqlStorage(_Storage):
 
     def wait_for_writes(self) -> None:
         """Return once any currently pending database modifications have been completed."""
+        _logger.debug("Waiting for writes")
+
         if hasattr(self, "batch_thread") and self.batch_thread is not None:
             # short circuit if the queue is empty
             with self.batch_thread.cond:
@@ -448,6 +458,7 @@ class SqlStorageBatchManager(_BatchManager):
         self._storage.batch_mode = False
         self._storage.batch_insert_values = None
         if self._storage.flush_on_batchctx_exit:
+            _logger.debug("Flushing on batch context exit")
             self._storage.wait_for_writes()
         return True
 


### PR DESCRIPTION
Implementation for #104 

When AnyVar starts up it will examine the value of the `ANYVAR_LOGGING_CONFIG` environment variable.  If the value points to a file, either absolute or relative path, AnyVar will attempt to load it, parse it as YAML and use the resulting data structure to configure the logging module using `dictConfig()`.