### PR TITLE
build: use importlib (pkg_resources is deprecated)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,3 +21,33 @@ jobs:
 
       - name: Check style
         run: python3 -m ruff check . && python3 -m ruff format --check .
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: zsh
+        version: 1.0
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: pip
+        cache-dependency-path: '**/setup.cfg'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install --use-deprecated=legacy-resolver '.[test,postgres,snowflake,queueing]'
+
+    - name: Test with pytest
+      run: pytest tests/storage/test_snowflake.py

--- a/src/anyvar/__init__.py
+++ b/src/anyvar/__init__.py
@@ -1,8 +1,7 @@
 """Import basic AnyVar objects."""
 
 import logging
-
-import pkg_resources
+from importlib.metadata import PackageNotFoundError, version
 
 _logger = logging.getLogger(__name__)
 
@@ -10,12 +9,10 @@ __all__ = ["AnyVar"]
 
 
 try:
-    __version__ = pkg_resources.get_distribution(__name__).version
+    __version__ = version(__name__)
     _logger.info("Package %s, version = %s", __name__, __version__)
-except pkg_resources.DistributionNotFound:
+except PackageNotFoundError:
     __version__ = "unknown"
-finally:
-    del pkg_resources
 
 
 from .anyvar import AnyVar  # isort:skip

--- a/src/anyvar/utils/types.py
+++ b/src/anyvar/utils/types.py
@@ -1,6 +1,6 @@
 """Provide helpful type definitions and references."""
 
-from enum import StrEnum
+from enum import Enum
 
 from ga4gh.vrs import models
 
@@ -24,7 +24,7 @@ variation_class_map = {
 }
 
 
-class SupportedVariationType(StrEnum):
+class SupportedVariationType(str, Enum):
     """Define constraints for supported variation types"""
 
     ALLELE = "Allele"


### PR DESCRIPTION
`pkg_resources` is no longer available by default in python 3.12: https://github.com/python/cpython/issues/95299

this PR uses the recommend `importlib` replacement. It also runs the Snowflake unit tests in CI as a base confirmation that the library is importable, since these tests are sufficiently mocked out.