### PR TITLE
build: pin VRS-Python 2.0a12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "fastapi>=0.95.0",
     "python-multipart",  # required for fastapi file uploads
     "uvicorn",
-    "ga4gh.vrs[extras]~=2.0.0a11",
+    "ga4gh.vrs[extras]==2.0.0a12",
     "sqlalchemy~=1.4.54",
     "pyyaml",
 ]


### PR DESCRIPTION
See https://github.com/biocommons/anyvar/discussions/111. Pinning `a12` for stability purposes in next release.