### PR TITLE
fix: don't use deprecated pkg_resources api for `__version__` value

### DIFF
--- a/src/anyvar/__init__.py
+++ b/src/anyvar/__init__.py
@@ -1,21 +1,11 @@
 """Import basic AnyVar objects."""
 
-import logging
-
-import pkg_resources
-
-_logger = logging.getLogger(__name__)
-
-__all__ = ["AnyVar"]
-
+from importlib.metadata import PackageNotFoundError, version
 
 try:
-    __version__ = pkg_resources.get_distribution(__name__).version
-    _logger.info("Package %s, version = %s", __name__, __version__)
-except pkg_resources.DistributionNotFound:
+    __version__ = version(__package__)
+except PackageNotFoundError:  # pragma: no cover
+    # package is not installed
     __version__ = "unknown"
-finally:
-    del pkg_resources
-
 
 from .anyvar import AnyVar  # isort:skip


### PR DESCRIPTION
close https://github.com/biocommons/anyvar/issues/175

pulled directly from https://github.com/biocommons/biocommons.example/blob/main/src/biocommons/example/__init__.py