### PR TITLE
feat: configure logging + provide exceptions in logs for API service

### DIFF
--- a/src/anyvar/restapi/main.py
+++ b/src/anyvar/restapi/main.py
@@ -219,7 +219,7 @@ def add_variation_annotation(
                 annotation=annotation.annotation,
             )
         except ValueError as e:
-            _logger.error(
+            _logger.exception(
                 "Failed to add annotation `%s` on variation `%s`", annotation, vrs_id
             )
             raise HTTPException(


### PR DESCRIPTION
* call `logging.basicConfig` so that a log file is actually created when the server runs. We usually do this further up in the module hierarchy but because `anyvar.restapi` is where the "app" stuff goes, I think we should do it here?
* use `logging.exception` in two places so we get the full stack trace in logs

### Questions/notes
* there's some code of moderate jankiness to configure anyvar-wide logging. This is done because `__package__` in `anyvar/restapi/main.py` will equal `"anyvar.restapi"`, not `"anyvar"`. We could also just set this to the literal `"anyvar"`.
* `logging.DEBUG` by default. We could make this configurable in any number of ways now or in the future -- thoughts?