### PR TITLE
feat: optionally don't return an annotated copy of input VCF

### DIFF
--- a/src/anyvar/restapi/main.py
+++ b/src/anyvar/restapi/main.py
@@ -454,7 +454,7 @@ async def annotate_vcf(
             description="When running asynchronously, use the specified value as the run id instead generating a random uuid",
         ),
     ] = None,
-    return_annotated_vcf: bool = True,
+    return_annotated_vcf: Annotated[bool, Query(description="sdlfjkj")] = True,
 ) -> FileResponse | RunStatusResponse | ErrorResponse | None:
     """Register alleles from a VCF and return a file annotated with VRS IDs.
 
@@ -511,6 +511,7 @@ async def _annotate_vcf_async(
     allow_async_write: bool,
     assembly: str,
     run_id: str | None,
+    return_annotated_vcf: bool,
 ) -> RunStatusResponse | ErrorResponse:
     """Annotate with VRS IDs asynchronously.  See `annotate_vcf()` for parameter definitions."""
     # if run_id is provided, validate it does not already exist
@@ -549,6 +550,7 @@ async def _annotate_vcf_async(
             "assembly": assembly,
             "for_ref": for_ref,
             "allow_async_write": allow_async_write,
+            "return_annotated_vcf": return_annotated_vcf,
         },
         task_id=run_id,
     )

--- a/src/anyvar/restapi/main.py
+++ b/src/anyvar/restapi/main.py
@@ -420,7 +420,7 @@ def register_vrs_object(
     tags=[EndpointTag.VARIATIONS],
     response_model=None,
 )
-async def annotate_vcf(
+async def ingest_vcf(
     request: Request,
     response: Response,
     bg_tasks: BackgroundTasks,
@@ -454,7 +454,12 @@ async def annotate_vcf(
             description="When running asynchronously, use the specified value as the run id instead generating a random uuid",
         ),
     ] = None,
-    return_annotated_vcf: Annotated[bool, Query(description="sdlfjkj")] = True,
+    return_annotated_vcf: Annotated[
+        bool,
+        Query(
+            description="Whether to return an annotated VCF. Disable if ingesting a VCF that has already been annotated."
+        ),
+    ] = True,
 ) -> FileResponse | RunStatusResponse | ErrorResponse | None:
     """Register alleles from a VCF and return a file annotated with VRS IDs.
 
@@ -489,6 +494,7 @@ async def annotate_vcf(
             allow_async_write=allow_async_write,
             assembly=assembly,
             run_id=run_id,
+            return_annotated_vcf=return_annotated_vcf,
         )
     # Run synchronously
     else:  # noqa: RET505

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -283,8 +283,11 @@ def test_vcf_submit_preannotated_with_output(
         os.environ, {"ANYVAR_VCF_ASYNC_WORK_DIR": "./", "CELERY_BROKER_URL": "redis://"}
     )
     resp = client.put("/vcf", files={"vcf": sample_vcf_grch38_annotated})
-    assert resp.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
-    assert resp.json() == {"error": "VCF registration failed.", "error_code": None}
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+    assert resp.json() == {
+        "error": "VCF registration failed: VRS annotations already present",
+        "error_code": None,
+    }
 
     status_resp = client.put(
         "/vcf", files={"vcf": sample_vcf_grch38_annotated}, params={"run_async": True}
@@ -294,6 +297,10 @@ def test_vcf_submit_preannotated_with_output(
     assert status_resp_json["status"] == "PENDING"
     resp = client.get(f"/vcf/{status_resp_json['run_id']}")
     assert resp.status_code == HTTPStatus.OK
+    assert resp.json() == {
+        "error": "VCF registration failed: VRS annotations already present",
+        "error_code": None,
+    }
 
 
 def test_vcf_submit_preannotated_no_output(


### PR DESCRIPTION
sufficient resolution of #177 for the short term.

Provide a parameter that enables/disables the annotated VCF file response. If it's turned off, then VRS-Python never tries to make a VCF output and never hits the problem that it needs to create INFO fields that already exist.

I think there are legitimate reasons you might use this, but it's a bit of a janky solution to my use case, and still raises issues like the possibility that the re-computed VRS IDs might differ from the submitted file. I think in the future maybe we could make additional endpoints or logic for updating/validating existing annotations during ingest.

### questions/TBD

* type of response?
* confirm tests pass