### PR TITLE
fix: ensure dotenv is available for celery worker

### DIFF
--- a/src/anyvar/queueing/celery_worker.py
+++ b/src/anyvar/queueing/celery_worker.py
@@ -9,10 +9,12 @@ from pathlib import Path
 import celery.signals
 from celery import Celery, Task
 from celery.result import AsyncResult
+from dotenv import load_dotenv
 
 import anyvar
 from anyvar.extras.vcf import VcfRegistrar
 
+load_dotenv()
 _logger = logging.getLogger(__name__)
 
 # Configure the Celery app


### PR DESCRIPTION
close #183 

Because both `main.py` and `celery_worker.py` are possible entry points depending on what you're doing, I think we just have to call `load_dotenv` twice. I don't really care about the performance aspect (seems almost nil) but I don't know if this risks some kind of new error, like if the env changes between the two times it's called? I dunno.