### PR TITLE
fix: remove redundant logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ dependencies = [
     "ga4gh.vrs[extras]~=2.1.2",
     "sqlalchemy~=1.4.54",
     "pyyaml",
-    "python-dotenv"
+    "python-dotenv",
+    "anyio",
 ]
 dynamic = ["version"]
 

--- a/src/anyvar/anyvar.py
+++ b/src/anyvar/anyvar.py
@@ -5,14 +5,11 @@ biological sequence variation
 
 import importlib.util
 import logging
-import logging.config
 import os
-import pathlib
 import warnings
 from collections.abc import MutableMapping
 from urllib.parse import urlparse
 
-import yaml
 from ga4gh.vrs.enderef import vrs_deref, vrs_enref
 
 from anyvar.storage import DEFAULT_STORAGE_URI, _Storage
@@ -23,18 +20,6 @@ from anyvar.utils.types import Annotation, AnnotationKey, VrsObject
 # Suppress pydantic warnings unless otherwise indicated
 if os.environ.get("ANYVAR_SHOW_PYDANTIC_WARNINGS", None) is None:
     warnings.filterwarnings("ignore", module="pydantic")
-
-# Configure logging from file or use default
-logging_config_file = os.environ.get("ANYVAR_LOGGING_CONFIG", None)
-if logging_config_file and pathlib.Path(logging_config_file).is_file():
-    with pathlib.Path(logging_config_file).open() as fd:
-        try:
-            config = yaml.safe_load(fd.read())
-            logging.config.dictConfig(config)
-        except Exception:
-            logging.exception(  # noqa: LOG015
-                "Error in Logging Configuration. Using default configs"
-            )
 
 _logger = logging.getLogger(__name__)
 

--- a/src/anyvar/restapi/main.py
+++ b/src/anyvar/restapi/main.py
@@ -87,10 +87,13 @@ async def app_lifespan(param_app: FastAPI):  # noqa: ANN201
                 contents = await f.read()
                 config = yaml.safe_load(contents)
                 logging.config.dictConfig(config)
+                _logger.info("Logging using configs set from %s", logging_config_file)
             except Exception:
-                logging.exception(  # noqa: LOG015
+                _logger.exception(
                     "Error in Logging Configuration. Using default configs"
                 )
+    else:
+        _logger.info("Logging with default configs.")
 
     # create anyvar instance
     storage = anyvar.anyvar.create_storage()

--- a/src/anyvar/restapi/main.py
+++ b/src/anyvar/restapi/main.py
@@ -4,6 +4,7 @@ import asyncio
 import datetime
 import json
 import logging
+import logging.config
 import os
 import pathlib
 import tempfile
@@ -13,7 +14,9 @@ from contextlib import asynccontextmanager
 from http import HTTPStatus
 from typing import Annotated
 
+import anyio
 import ga4gh.vrs
+import yaml
 from dotenv import load_dotenv
 from fastapi import (
     BackgroundTasks,
@@ -76,13 +79,18 @@ async def app_lifespan(param_app: FastAPI):  # noqa: ANN201
     """Initialize AnyVar instance and associate with FastAPI app on startup
     and teardown the AnyVar instance on shutdown
     """
-    # initialize logs
-    name = __name__.split(".")[0]
-    logging.basicConfig(
-        filename=f"{name}.log",
-        format="[%(asctime)s] - %(name)s - %(levelname)s : %(message)s",
-    )
-    logging.getLogger(name).setLevel(logging.DEBUG)
+    # Configure logging from file or use default
+    logging_config_file = os.environ.get("ANYVAR_LOGGING_CONFIG", None)
+    if logging_config_file and pathlib.Path(logging_config_file).is_file():
+        async with await anyio.open_file(logging_config_file) as f:
+            try:
+                contents = await f.read()
+                config = yaml.safe_load(contents)
+                logging.config.dictConfig(config)
+            except Exception:
+                logging.exception(  # noqa: LOG015
+                    "Error in Logging Configuration. Using default configs"
+                )
 
     # create anyvar instance
     storage = anyvar.anyvar.create_storage()


### PR DESCRIPTION
(ope) in https://github.com/biocommons/anyvar/pull/178 I added some more descriptive logging calls and also inserted a basic configuration call into the FastAPI app lifespan. I forgot that we already enabled use of a logging config to be loaded from a yaml file at `ANYVAR_LOGGING_CONFIG`. This PR moves the richer configuration stuff into the app lifespan code and gets rid of the redundant stuff. 

It does add an explicit `anyio` dependency, but that was already an implicit dependency via fastapi things.