### PR TITLE
feat: return 501 if annotations are unsupported

### DIFF
--- a/src/anyvar/restapi/main.py
+++ b/src/anyvar/restapi/main.py
@@ -264,6 +264,11 @@ def add_variation_annotation(
                 status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
                 detail=f"Failed to add annotation: {annotation}",
             ) from e
+    else:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_IMPLEMENTED,
+            detail="Annotations are not supported by this backend configuration.",
+        )
 
     return AddAnnotationResponse(
         messages=messages,
@@ -293,12 +298,13 @@ def get_variation_annotation(
     :param annotation_type: type of annotation to retrieve
     :return: response object containing list of annotations for the variation
     """
-    # Retrieve the annotation from the annotation store
-    if hasattr(request.app.state, "anyannotation"):
-        anyannotation: AnyAnnotation = request.app.state.anyannotation
-        annotations = anyannotation.get_annotation(vrs_id, annotation_type)
-    else:
-        annotations = []
+    if not hasattr(request.app.state, "anyannotation"):
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_IMPLEMENTED,
+            detail="Annotations are not supported by this backend configuration.",
+        )
+    anyannotation: AnyAnnotation = request.app.state.anyannotation
+    annotations = anyannotation.get_annotation(vrs_id, annotation_type)
 
     return GetAnnotationResponse(annotations=annotations)
 


### PR DESCRIPTION
Currently the API will fail silently if the instance is not configured to support annotations. This PR adds a `501 Not Implemented` response to particular endpoints to make it clear why annotations are failing to appear.
