### PR TITLE
fix: remove `search_variations` and `get_variation_count` declarations from the `_Storage` class

### DIFF
--- a/src/anyvar/storage/__init__.py
+++ b/src/anyvar/storage/__init__.py
@@ -26,25 +26,6 @@ class _Storage(MutableMapping):
     def close(self) -> None:
         """Close the storage integration and cleans up any resources"""
 
-    @abstractmethod
-    def search_variations(self, refget_accession: str, start: int, stop: int) -> list:
-        """Find all alleles that were registered that are in 1 genomic region
-
-        :param refget_accession: refget accession (SQ. identifier)
-        :param start: Start genomic region to query
-        :param stop: Stop genomic region to query
-
-        :raise NotImplementedError:
-        """
-
-    @abstractmethod
-    def get_variation_count(self, variation_type: VariationStatisticType) -> int:
-        """Get total # of registered variations of requested type.
-
-        :param variation_type: variation type to check
-        :return: total count
-        """
-
 
 class _BatchManager(AbstractContextManager):
     """Base context management class for batch writing.


### PR DESCRIPTION
In Issue #228, I added abstract declarations for `search_variations` and `get_variation_count` declarations in the `_Storage` class, which is the abstract base parent class of all other storage classes in AnyVar. I forgot that the Annotation Storage classes _also_ inherit from this, but they of course do not implement these methods. That _\*ahem\*_ may have broken things. This PR reverts that change so that AnyVar works again.

closes ##238