### PR TITLE
API workers deadlock under heavy load using async VCF annotation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dynamic = ["version"]
 postgres = ["psycopg[binary]"]
 snowflake = ["snowflake-sqlalchemy~=1.5.1"]
 queueing = [
-    "celery[redis]~=5.4.0",
+    "celery[redis]~=5.5.0",
     "aiofiles",
 ]
 duckdb = [

--- a/src/anyvar/restapi/vcf.py
+++ b/src/anyvar/restapi/vcf.py
@@ -94,10 +94,10 @@ async def _annotate_vcf_async(
     )
 
     vcf_site_count = 0
+    newline_bytes = b"\n"
     async with aiofiles.open(input_file_path, mode="wb") as fd:
         while buffer := await vcf.read(1024 * 1024):
-            if ord("\n") in buffer:
-                vcf_site_count = vcf_site_count + 1
+            vcf_site_count += buffer.count(newline_bytes)
             await fd.write(buffer)
     _logger.debug(
         "wrote working file for async run %s vcf to %s", run_id, input_file_path

--- a/src/anyvar/restapi/vcf.py
+++ b/src/anyvar/restapi/vcf.py
@@ -49,6 +49,11 @@ _logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+# high side estimate for time is 500 variants per second
+_expected_vrs_ids_per_second = int(
+    os.getenv("ANYVAR_EXPECTED_VRS_IDS_PER_SECOND", "500")
+)
+
 
 async def _annotate_vcf_async(
     response: Response,
@@ -115,10 +120,14 @@ async def _annotate_vcf_async(
     # set response headers
     response.status_code = status.HTTP_202_ACCEPTED
     response.headers["Location"] = f"/vcf/{task_result.id}"
-    # low side estimate for time is 333 variants per second
-    retry_after = max(1, round((vcf_site_count * (2 if for_ref else 1)) / 333, 0))
+    retry_after = max(
+        1,
+        round(
+            (vcf_site_count * (2 if for_ref else 1)) / _expected_vrs_ids_per_second, 0
+        ),
+    )
     _logger.debug("%s - retry after is %s", task_result.id, str(retry_after))
-    response.headers["Retry-After"] = str(retry_after)
+    response.headers["Retry-After"] = str(int(retry_after))
     return RunStatusResponse(
         run_id=task_result.id,
         status="PENDING",
@@ -599,8 +608,10 @@ async def get_vcf_run_status(
                 status_message="Run not found",
             )
         # status is "SENT" - return 202
+        #  with retry after 2 seconds
         else:  # noqa: RET505
             response.status_code = status.HTTP_202_ACCEPTED
+            response.headers["Retry-After"] = "2"
             return RunStatusResponse(
                 run_id=run_id,
                 status="PENDING",

--- a/src/anyvar/restapi/vcf.py
+++ b/src/anyvar/restapi/vcf.py
@@ -629,13 +629,17 @@ async def get_vcf_run_status(
         # the after_task_publish handler sets the state to "SENT"
         #  so a status of PENDING is actually unknown task
         # but there can be a race condition, so if status is pending
-        #  pause half a second and check again
+        #  pause half a second at a time up to 5 seconds
         if async_result.status == "PENDING":
-            await asyncio.sleep(0.5)
-            async_result = AsyncResult(id=run_id)
-            _logger.debug(
-                "%s - after 0.5 second wait, status is %s", run_id, async_result.status
-            )
+            for _ in range(10):
+                await asyncio.sleep(0.5)
+                _logger.debug(
+                    "%s - after 0.5 second wait, status is %s",
+                    run_id,
+                    async_result.status,
+                )
+                if async_result.status != "PENDING":
+                    break
 
         # status is "PENDING" - unknown run id
         if async_result.status == "PENDING":

--- a/tests/vcf/test_annotate_vcf.py
+++ b/tests/vcf/test_annotate_vcf.py
@@ -16,6 +16,7 @@ from pytest_mock import MockerFixture
 
 import anyvar.anyvar
 from anyvar.queueing.celery_worker import celery_app
+from anyvar.restapi.vcf import _working_file_cleanup
 
 
 @pytest.fixture
@@ -241,7 +242,7 @@ def test_vcf_submit_duplicate_run_id(
     assert "error" in resp.json()
     assert (
         resp.json()["error"]
-        == "An existing run with id 12345 is SENT.  Fetch the completed run result before submitting with the same run_id."
+        == "An existing run with id 12345 is SENT. Fetch the completed run result before submitting with the same run_id."
     )
 
 
@@ -273,7 +274,7 @@ def test_vcf_get_result_success(client: TestClient, mocker: MockerFixture):
     with pathlib.Path(__file__).open(mode="rb") as fd:
         assert resp.content == fd.read()
     mock_result.return_value.forget.assert_called_once()
-    mock_bg_tasks.assert_called_with(os.unlink, __file__)
+    mock_bg_tasks.assert_called_with(_working_file_cleanup, __file__)
 
 
 def test_vcf_get_result_failure_timeout(client: TestClient, mocker: MockerFixture):


### PR DESCRIPTION
Updates to resolve deadlock issue in REST API for asynchronous VCF annotation.

- Remove unnecessary re-creation of `AsyncResult` in `get_vcf_run_status()`
- Upgrade Celery to 5.5
- Improve observability with additional logging `anyvar.restapi.vcf` module
- Fix calculation for retry-after header

Port of changes originally made to 0.9.0 version: https://github.com/biocommons/anyvar/pull/257

Closes #256 