### PR TITLE
feat: add `mappings` table

### DIFF
--- a/src/anyvar/restapi/main.py
+++ b/src/anyvar/restapi/main.py
@@ -356,14 +356,11 @@ async def add_registration_annotations(
                 },
             )
 
-        liftover_annotations = annotator.get_annotation(input_vrs_id, "liftover")
-        if not liftover_annotations:
-            liftover_utils.add_liftover_annotations(
-                input_vrs_id=input_vrs_id,
-                input_vrs_variant_dict=input_variant,
-                anyvar=request.app.state.anyvar,
-                annotator=annotator,
-            )
+    liftover_utils.add_liftover_mapping(
+        input_vrs_id=input_vrs_id,
+        input_vrs_variant_dict=input_variant,
+        anyvar=request.app.state.anyvar,
+    )
 
     return new_response
 

--- a/src/anyvar/restapi/mappings.py
+++ b/src/anyvar/restapi/mappings.py
@@ -1,0 +1,1 @@
+"""Provide routes for variation mapping CRUD operations"""

--- a/src/anyvar/storage/base_storage.py
+++ b/src/anyvar/storage/base_storage.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable
 
 from ga4gh.vrs import models as vrs_models
+from pydantic import BaseModel
 
 
 class StoredObjectType(enum.StrEnum):
@@ -24,6 +25,14 @@ class VariationMappingType(enum.StrEnum):
     LIFTOVER = "liftover"
     TRANSCRIPTION = "transcription"
     TRANSLATION = "translation"
+
+
+class VariationMapping(BaseModel):
+    """Mapping between variation instances"""
+
+    source_id: str
+    dest_id: str
+    mapping_type: VariationMappingType
 
 
 class Storage(ABC):

--- a/src/anyvar/storage/mapper_registry.py
+++ b/src/anyvar/storage/mapper_registry.py
@@ -33,7 +33,7 @@ class MapperRegistry:
             orm.Allele: AlleleMapper(),
             orm.Location: SequenceLocationMapper(),
             orm.SequenceReference: SequenceReferenceMapper(),
-            orm.VariationMapping: VariationMappingMapper,
+            orm.VariationMapping: VariationMappingMapper(),
         }
 
     def get_mapper(self, entity_type: type[T]) -> BaseMapper:

--- a/src/anyvar/storage/mapper_registry.py
+++ b/src/anyvar/storage/mapper_registry.py
@@ -5,11 +5,13 @@ from typing import TypeVar
 from ga4gh.vrs import models as vrs_models
 
 from anyvar.storage import orm
+from anyvar.storage.base_storage import VariationMapping
 from anyvar.storage.mappers import (
     AlleleMapper,
     BaseMapper,
     SequenceLocationMapper,
     SequenceReferenceMapper,
+    VariationMappingMapper,
 )
 
 T = TypeVar("T")
@@ -24,12 +26,14 @@ class MapperRegistry:
             vrs_models.Allele: orm.Allele,
             vrs_models.SequenceLocation: orm.Location,
             vrs_models.SequenceReference: orm.SequenceReference,
+            VariationMapping: orm.VariationMapping,
         }
 
         self._mappers: dict[type, BaseMapper] = {
             orm.Allele: AlleleMapper(),
             orm.Location: SequenceLocationMapper(),
             orm.SequenceReference: SequenceReferenceMapper(),
+            orm.VariationMapping: VariationMappingMapper,
         }
 
     def get_mapper(self, entity_type: type[T]) -> BaseMapper:

--- a/src/anyvar/storage/mappers.py
+++ b/src/anyvar/storage/mappers.py
@@ -4,8 +4,10 @@ from abc import ABC, abstractmethod
 from typing import Generic, TypeVar
 
 from ga4gh.vrs import models as vrs_models
+from sqlalchemy.orm import relationship
 
 from anyvar.storage import orm
+from anyvar.storage.base_storage import VariationMapping, VariationMappingType
 
 V = TypeVar("V")  # VRS model type
 A = TypeVar("A")  # AnyVar DB entity type
@@ -185,3 +187,24 @@ class AlleleMapper(BaseMapper[vrs_models.Allele, orm.Allele]):
         if state_type == "LengthExpression":
             return vrs_models.LengthExpression(**state_data)
         raise ValueError(f"Unknown state type '{state_type}' from: {state_data}")
+
+
+class VariationMappingMapper(BaseMapper[VariationMapping, orm.VariationMapping]):
+    """Maps between VariationMapping entities."""
+
+    def from_db_entity(self, db_entity: orm.VariationMapping) -> VariationMapping:
+        """Convert DB instance into business logic object"""
+        mapping_type = VariationMappingType(db_entity.relationship_type)
+        return VariationMapping(
+            source_id=db_entity.source_id,
+            dest_id=db_entity.dest_id,
+            mapping_type=mapping_type,
+        )
+
+    def to_db_entity(self, vrs_model: VariationMapping) -> orm.VariationMapping:
+        """Convert VariationMapping object to DB mapping instance."""
+        return orm.VariationMapping(
+            source_id=vrs_model.source_id,
+            dest_id=vrs_model.dest_id,
+            relationship_type=vrs_model.mapping_type,
+        )

--- a/src/anyvar/storage/mappers.py
+++ b/src/anyvar/storage/mappers.py
@@ -206,5 +206,5 @@ class VariationMappingMapper(BaseMapper[VariationMapping, orm.VariationMapping])
         return orm.VariationMapping(
             source_id=vrs_model.source_id,
             dest_id=vrs_model.dest_id,
-            relationship_type=vrs_model.mapping_type,
+            mapping_type=vrs_model.mapping_type,
         )

--- a/src/anyvar/storage/orm.py
+++ b/src/anyvar/storage/orm.py
@@ -1,6 +1,9 @@
 """SQLAlchemy ORM models for AnyVar database schema."""
 
-from sqlalchemy import ForeignKey, Index, String, create_engine
+from uuid import UUID
+
+from sqlalchemy import ForeignKey, Index, String, create_engine, func
+from sqlalchemy.dialects.postgresql import ENUM as PgEnum  # noqa: N811
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import (
     DeclarativeBase,
@@ -9,6 +12,8 @@ from sqlalchemy.orm import (
     relationship,
     sessionmaker,
 )
+
+from anyvar.storage.base_storage import VariationMappingType
 
 
 class Base(DeclarativeBase):
@@ -89,6 +94,33 @@ class Annotation(Base):
             "object_id",
             "annotation_type",
         ),
+    )
+
+
+relationship_type_enum = PgEnum(
+    VariationMappingType,
+    name="relationship_type",
+    metadata=Base.metadata,
+    create_type=True,
+    validate_strings=True,
+)
+
+
+class VariationMapping(Base):
+    """AnyVar ORM model for variation-to-variation mapping"""
+
+    __tablename__ = "variation_mappings"
+
+    id: Mapped[UUID] = mapped_column(
+        primary_key=True, server_default=func.gen_random_uuid()
+    )
+    source_id: Mapped[str] = mapped_column(String, ForeignKey("alleles.id"))
+    dest_id: Mapped[str] = mapped_column(String, ForeignKey("alleles.id"))
+    relationship_type: Mapped[str] = mapped_column(relationship_type_enum)
+
+    __table_args__ = (
+        Index("idx_mappings_source_id", "source_id"),
+        Index("ids_mappings_dest_id", "dest_id"),
     )
 
 

--- a/src/anyvar/storage/orm.py
+++ b/src/anyvar/storage/orm.py
@@ -97,9 +97,9 @@ class Annotation(Base):
     )
 
 
-relationship_type_enum = PgEnum(
+mapping_type_enum = PgEnum(
     VariationMappingType,
-    name="relationship_type",
+    name="mapping_type",
     metadata=Base.metadata,
     create_type=True,
     validate_strings=True,
@@ -116,12 +116,12 @@ class VariationMapping(Base):
     )
     source_id: Mapped[str] = mapped_column(String, ForeignKey("alleles.id"))
     dest_id: Mapped[str] = mapped_column(String, ForeignKey("alleles.id"))
-    relationship_type: Mapped[str] = mapped_column(relationship_type_enum)
+    mapping_type: Mapped[str] = mapped_column(mapping_type_enum)
 
     __table_args__ = (
         Index("idx_mappings_source_id", "source_id"),
         Index("ids_mappings_dest_id", "dest_id"),
-        UniqueConstraint("source_id", "dest_id", "relationship_type"),
+        UniqueConstraint("source_id", "dest_id", "mapping_type"),
     )
 
 

--- a/src/anyvar/storage/orm.py
+++ b/src/anyvar/storage/orm.py
@@ -2,7 +2,7 @@
 
 from uuid import UUID
 
-from sqlalchemy import ForeignKey, Index, String, create_engine, func
+from sqlalchemy import ForeignKey, Index, String, UniqueConstraint, create_engine, func
 from sqlalchemy.dialects.postgresql import ENUM as PgEnum  # noqa: N811
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import (
@@ -121,6 +121,7 @@ class VariationMapping(Base):
     __table_args__ = (
         Index("idx_mappings_source_id", "source_id"),
         Index("ids_mappings_dest_id", "dest_id"),
+        UniqueConstraint("source_id", "dest_id", "relationship_type"),
     )
 
 

--- a/src/anyvar/storage/postgres.py
+++ b/src/anyvar/storage/postgres.py
@@ -222,9 +222,22 @@ class PostgresObjectStore(Storage):
             mapping_type=mapping_type,
         )
         db_mapping_instance = mapper_registry.to_db_entity(mapping_instance)
-        stmt = insert(DbVariationMapping).on_conflict_do_nothing()
+        # TODO use ORM thing
+        stmt = (
+            insert(DbVariationMapping)
+            .values(
+                [
+                    {
+                        "source_id": source_object_id,
+                        "dest_id": destination_object_id,
+                        "relationship_type": "liftover",  # TODO use enum properly
+                    }
+                ]
+            )
+            .on_conflict_do_nothing()
+        )
         with self.session_factory() as session, session.begin():
-            session.execute(stmt, db_mapping_instance)
+            session.execute(stmt)
 
     def delete_mapping(
         self,

--- a/src/anyvar/storage/postgres.py
+++ b/src/anyvar/storage/postgres.py
@@ -60,6 +60,7 @@ class PostgresObjectStore(Storage):
         """Wipe all data from the storage backend."""
         with self.session_factory() as session, session.begin():
             # Delete all data from tables in dependency order
+            session.execute(delete(DbVariationMapping))
             session.execute(delete(Allele))
             session.execute(delete(Location))
             session.execute(delete(SequenceReference))
@@ -230,7 +231,7 @@ class PostgresObjectStore(Storage):
                     {
                         "source_id": source_object_id,
                         "dest_id": destination_object_id,
-                        "relationship_type": "liftover",  # TODO use enum properly
+                        "mapping_type": "liftover",  # TODO use enum properly
                     }
                 ]
             )
@@ -255,7 +256,7 @@ class PostgresObjectStore(Storage):
             delete(DbVariationMapping)
             .where(DbVariationMapping.source_id == source_object_id)
             .where(DbVariationMapping.dest_id == destination_object_id)
-            .where(DbVariationMapping.relationship_type == mapping_type)
+            .where(DbVariationMapping.mapping_type == mapping_type)
         )
         with self.session_factory() as session, session.begin():
             session.execute(stmt)
@@ -273,7 +274,7 @@ class PostgresObjectStore(Storage):
         stmt = (
             select(DbVariationMapping)
             .where(DbVariationMapping.source_id == source_object_id)
-            .where(DbVariationMapping.relationship_type == mapping_type)
+            .where(DbVariationMapping.mapping_type == mapping_type)
         )
         with self.session_factory() as session, session.begin():
             result = session.execute(stmt)

--- a/tests/test_liftover.py
+++ b/tests/test_liftover.py
@@ -2,12 +2,13 @@ import copy
 
 import pytest
 from data.liftover_variants import test_variants
+from starlette.testclient import TestClient
 
 from anyvar.utils import liftover_utils
 from anyvar.utils.funcs import build_vrs_variant_from_dict
 
 
-def extract_variants(variant_name):
+def extract_variants(variant_name: str) -> tuple:
     variant_test_case = copy.deepcopy(test_variants[variant_name])
     return (variant_test_case["variant_input"], variant_test_case["expected_output"])
 
@@ -57,7 +58,7 @@ def invalid_variant():
 
 # Cases where liftover should be successful
 SUCCESS_CASES = [
-    "copynumber_ranged_positive_grch37_variant",
+    # "copynumber_ranged_positive_grch37_variant",  # TODO restore upon support for copy number variants
     "allele_int_negative_grch38_variant",
     "allele_int_unknown_grch38_variant",
 ]
@@ -77,7 +78,9 @@ NO_LIFTOVER_CASES = ["empty_variation_object", "invalid_variant"]
 ## Tests for src/anyvar/utils/liftover_utils.py > 'get_liftover_variant' function ##
 ####################################################################################
 @pytest.mark.parametrize("variant_fixture_name", SUCCESS_CASES)
-def test_liftover_success(request, variant_fixture_name, client):
+def test_liftover_success(
+    request: pytest.FixtureRequest, variant_fixture_name: str, client: TestClient
+):
     variant_input, expected_output = request.getfixturevalue(variant_fixture_name)
     lifted_over_variant_output = liftover_utils.get_liftover_variant(
         build_vrs_variant_from_dict(variant_input), client.app.state.anyvar
@@ -92,74 +95,3 @@ def test_liftover_failure(request, variant_fixture_name, client):
         liftover_utils.get_liftover_variant(
             build_vrs_variant_from_dict(variant_input), client.app.state.anyvar
         )
-
-
-######################################################################################################
-## Tests for the middleware function src/anyvar/restapi/main.py > 'add_liftover_annotation' ##
-######################################################################################################
-@pytest.mark.parametrize(
-    "variant_fixture_name",
-    SUCCESS_CASES,
-)
-def test_liftover_annotation_success(request, variant_fixture_name, client):
-    # Ensure we have a clean slate for each test case
-    annotator = client.app.state.anyannotation
-    annotator.reset_mock()
-
-    variant_input, expected_lifted_over_variant = request.getfixturevalue(
-        variant_fixture_name
-    )
-    client.put("/vrs_variation", json=variant_input)
-
-    annotator.put_annotation.assert_any_call(
-        object_id=variant_input.get("id"),
-        annotation_type="liftover",
-        annotation={"liftover": expected_lifted_over_variant.model_dump().get("id")},
-    )
-
-    # TODO: we'll need to update this when we implement logic to verify that the liftover is reversible,
-    # because then if the liftover is NOT reversible, this `put_annotation` call won't trigger. See Issue # 195.
-    annotator.put_annotation.assert_any_call(
-        object_id=expected_lifted_over_variant.model_dump().get("id"),
-        annotation_type="liftover",
-        annotation={"liftover": variant_input.get("id")},
-    )
-
-
-@pytest.mark.parametrize(
-    "variant_fixture_name",
-    FAILURE_CASES,
-)
-def test_liftover_annotation_failure(request, variant_fixture_name, client):
-    # Ensure we have a clean slate for each test case
-    annotator = client.app.state.anyannotation
-    annotator.reset_mock()
-
-    variant_input, expected_lifted_over_variant = request.getfixturevalue(
-        variant_fixture_name
-    )
-    client.put("/vrs_variation", json=variant_input)
-
-    # Variants that can be registered successfully but are unable to be lifted over are annotated with an error message.
-    annotator.put_annotation.assert_called_with(
-        object_id=variant_input.get("id"),
-        annotation_type="liftover",
-        annotation={"liftover": expected_lifted_over_variant.get_error_message()},
-    )
-
-
-@pytest.mark.parametrize(
-    "variant_fixture_name",
-    NO_LIFTOVER_CASES,
-)
-def test_liftover_annotation_not_attempted(request, variant_fixture_name, client):
-    # Ensure we have a clean slate for each test case
-    annotator = client.app.state.anyannotation
-    annotator.reset_mock()
-
-    variant_input, _ = request.getfixturevalue(variant_fixture_name)
-    client.put("/vrs_variation", json=variant_input)
-
-    # Variant was invalid, so it should not have been registered; which means
-    # we shouldn't have tried to make any liftover annotations for it at all
-    annotator.put_annotation.assert_not_called()


### PR DESCRIPTION
* add `VariationMappings` table to postgresql implementation

## TODO
* update `nodb`

## Questions
* Provide some sort of description/meta column in mappings table?
* How to handle failed liftover? Previously we would add an annotation with a note about the failed liftover. Is this still something to support?

## Notes
* The existing e2e tests relied upon a mock of the Annotation table. We've talked about trying to move away from that means of testing for maintainability reasons, but there's no immediate replacement because we haven't added mappings CRUD methods to `anyvar.AnyVar` or endpoints to the REST API yet (i.e. there's no way to verify behavior outside of the storage class itself). 