### PR TITLE
feat: allow table name overrrides (issue #252)

### DIFF
--- a/src/anyvar/storage/orm.py
+++ b/src/anyvar/storage/orm.py
@@ -21,7 +21,7 @@ class Base(DeclarativeBase):
     @declared_attr.directive
     def __tablename__(cls) -> str:  # noqa: N805 (param name here should be 'cls', not 'self')
         # Default table name = class name, transformed from PascalCase into snake_case and pluralized.
-        # NOTE: May need more robust pluralization in the future to support additional classes/tables.
+        # NOTE: Classes/tables that require a different pluralization scheme should override this function.
         default_name: str = re.sub(r"(?<!^)(?=[A-Z])", "_", cls.__name__).lower() + "s"
 
         # Environment variable name is the class name transformed into UPPER_SNAKE_CASE, pluralized, and prefixed by 'ANYVAR_' + suffixed with "_TABLE_NAME".


### PR DESCRIPTION
closes #252 

## Pluralization 

Note that I maintained our convention of utilizing pluralized table names by simply appending an "s" to the end of the ORM class names when creating the tables. This will obviously not work in the future if we decide to add classes that are pluralized irregularly (e.g., a class named `Mouse` would produce a table named `mouses`, which is of course incorrect).

There are libraries that can handle this problem for us, but since our current tables don't require this solve, I opted for this simple solution instead. However, if we think it wise to make our pluralization more robust now so that we're protected in the future, I can change this.

## About `@declared_attr.directive`

See the SqlAlchemy documentation on this [here](https://docs.sqlalchemy.org/en/20/orm/mapping_api.html#sqlalchemy.orm.declared_attr) if you're curious