### PR TITLE
cicd: use uv and cache dependencies

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,7 +25,6 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: |
         run: uv sync --extra dev
 
       - name: Check style


### PR DESCRIPTION
Significantly reduces CI/CD time by caching dependencies and using a quicker dependency resolution method. This matches what we use in our other lab projects.