### PR TITLE
chore: add VCF benchmarking script

### DIFF
--- a/scripts/vcf_benchmark.py
+++ b/scripts/vcf_benchmark.py
@@ -10,6 +10,8 @@
 import logging
 import time
 from concurrent.futures import ProcessPoolExecutor
+from enum import StrEnum
+from functools import partial
 from json import JSONDecodeError
 from pathlib import Path
 from timeit import default_timer as timer
@@ -28,53 +30,82 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-HTTP_TIMEOUT = 60
+HTTP_TIMEOUT = 120
 
 
-def submit_variants(file: Path, anyvar_host: str) -> None:
+def submit_variants(
+    file: Path,
+    anyvar_host: str,
+    for_ref: bool,
+    allow_async_write: bool,
+    assembly: str,
+    run_async: bool,
+) -> None:
     with file.open("rb") as f:
         response = requests.put(
             f"{anyvar_host}/vcf",
             files={"vcf": (file.name, f, "text/plain")},
             params={
-                "allow_async_write": True,
-                "run_async": True,
-                "require_validation": False,
+                "for_ref": for_ref,
+                "allow_async_write": allow_async_write,
+                "assembly": assembly,
+                "run_async": run_async,
             },
             timeout=HTTP_TIMEOUT,
             headers={"accept": "application/json"},
         )
     logger.info("Submitting VCF to ingestion endpoint")
     response.raise_for_status()
-    run_id = response.json()["run_id"]
-    logger.info("Submission successful for %s", run_id)
-    while True:
-        logger.info("Polling ingestion status...")
-        time.sleep(5)
-        response = requests.get(f"{anyvar_host}/vcf/{run_id}", timeout=HTTP_TIMEOUT)
-        try:
-            if response.json()["status"] != "PENDING":
-                logger.info("Ingestion complete!")
-                break
-        except JSONDecodeError:
-            # presumably a successful response
-            if response.text.startswith("##fileformat="):
-                logger.info("Annotated VCF returned successfully")
-            else:
-                filename = f"vcf_benchmark_output_{run_id}"
-                with Path(filename).open("w") as f:
-                    f.write(response.text)
-                logger.info(
-                    "Received malformed response from vcf run ID lookup. Saved to %s",
-                    filename,
-                )
-            break
+    if run_async:
+        run_id = response.json()["run_id"]
+        logger.info("Submission successful for %s", run_id)
+        while True:
+            logger.info("Polling ingestion status...")
+            time.sleep(5)
+            response = requests.get(f"{anyvar_host}/vcf/{run_id}", timeout=HTTP_TIMEOUT)
+            try:
+                if response.json()["status"] != "PENDING":
+                    logger.info("Ingestion complete!")
+                    break
+            except JSONDecodeError:
+                # presumably a successful response
+                if response.text.startswith("##fileformat="):
+                    logger.info("Annotated VCF returned successfully")
+                else:
+                    filename = f"vcf_benchmark_output_{run_id}"
+                    with Path(filename).open("w") as f:
+                        f.write(response.text)
+                    logger.info(
+                        "Received malformed response from vcf run ID lookup. Saved to %s",
+                        filename,
+                    )
+                return
+    # don't need to poll for sync response
+    # timeouts should be expected for larger files though
+    if response.text.startswith("##fileformat="):
+        logger.info("Annotated VCF returned successfully")
+    else:
+        logger.info("Something has gone wrong: %s", response.text)
 
 
-def process_file(filepath: Path) -> None:
+class AssemblyOption(StrEnum):
+    GRCH38 = "GRCh38"
+    GRCH37 = "GRCh37"
+
+
+def process_file(
+    filepath: Path,
+    *,
+    for_ref: bool,
+    allow_async_write: bool,
+    assembly: str,
+    run_async: bool,
+) -> None:
     anyvar_host = "http://localhost:8000"
     start = timer()
-    submit_variants(filepath, anyvar_host)
+    submit_variants(
+        filepath, anyvar_host, for_ref, allow_async_write, assembly, run_async
+    )
     end = timer()
     logger.info("Completed VCF submission of %s in %s", filepath, f"{end - start:.5f}")
 
@@ -88,14 +119,32 @@ def process_file(filepath: Path) -> None:
     show_default=True,
     help="Number of parallel workers",
 )
-def main(filepaths: tuple[Path], workers: int):
+@click.option("--for-ref", type=bool, default=True)
+@click.option("--allow-async-write", type=bool, default=True)
+@click.option("--assembly", type=click.Choice(AssemblyOption, case_sensitive=False))
+@click.option("--run-async", type=bool, default=True)
+def main(
+    filepaths: tuple[Path],
+    workers: int,
+    for_ref: bool,
+    allow_async_write: bool,
+    assembly: str,
+    run_async: bool,
+):
     logger.info("Received %s file(s):", len(filepaths))
     for fp in filepaths:
         logger.info("- %s", fp)
     logger.info("Using %s workers", workers)
     start = timer()
+    _process_file = partial(
+        process_file,
+        for_ref=for_ref,
+        allow_async_write=allow_async_write,
+        assembly=assembly,
+        run_async=run_async,
+    )
     with ProcessPoolExecutor(max_workers=workers) as executor:
-        results = list(executor.map(process_file, filepaths))
+        results = list(executor.map(_process_file, filepaths))
     for result in results:
         logger.info(result)
 


### PR DESCRIPTION
close #275 

Well, I'm not sure if this closes 275, it depends on what we were thinking for that issue. But this is a thin rewrite of a script I wrote up for GREGoR that can be used to benchmark VCF submissions. It can take multiple input files as arguments and progressively submit them/monitor their progress against a running AnyVar API. There's a multiprocessing part that's there not for benchmarking per se but as a convenience for adding a bunch of big VCFs (eg GREGoR).

Initial unscientific testing on my laptop indicated that the current `storage-refactor-epic` commit performed about as well as `main` on a small (10k records) VCF

## Questions
* Currently polls the status endpoint every 5 seconds. That might be too long