### PR TITLE
chore: remove unused type annotations

### DIFF
--- a/src/anyvar/extras/vcf.py
+++ b/src/anyvar/extras/vcf.py
@@ -124,14 +124,14 @@ def register_existing_annotations(
                 if vrs_id == ".":
                     continue
                 true_state = "" if state == "." else state
-                seq_ref = vrs_models.SequenceReference(refgetAccession=refget_accession)  # pyright: ignore[reportCallIssue] - values that aren't specified default to `None`
+                seq_ref = vrs_models.SequenceReference(refgetAccession=refget_accession)
                 location = vrs_models.SequenceLocation(
                     sequenceReference=seq_ref, start=start, end=end
-                )  # pyright: ignore[reportCallIssue]
+                )
                 location_id = ga4gh_identify(location)
                 location.id = location_id
-                lse = vrs_models.LiteralSequenceExpression(sequence=true_state)  # pyright: ignore[reportCallIssue]
-                allele = vrs_models.Allele(location=location, state=lse)  # pyright: ignore[reportCallIssue]
+                lse = vrs_models.LiteralSequenceExpression(sequence=true_state)  # pyright: ignore[reportArgumentType]
+                allele = vrs_models.Allele(location=location, state=lse)
                 allele = normalize(allele, av.translator.dp)
                 new_vrs_id = ga4gh_identify(allele)
                 if conflict_logfile and new_vrs_id != vrs_id:

--- a/src/anyvar/restapi/main.py
+++ b/src/anyvar/restapi/main.py
@@ -441,7 +441,7 @@ def register_vrs_object(
     )
 
     return RegisterVariationResponse(
-        object=variation_object,  # type: ignore
+        object=variation_object,
         object_id=v_id,
         messages=liftover_messages or [],
     )

--- a/src/anyvar/utils/liftover_utils.py
+++ b/src/anyvar/utils/liftover_utils.py
@@ -213,8 +213,8 @@ def get_liftover_variant(input_variant: VrsVariation, anyvar: AnyVar) -> VrsVari
         type="SequenceLocation",
         sequenceReference=models.SequenceReference(
             type="SequenceReference", refgetAccession=converted_refget_accession
-        ),  # type: ignore (missing parameters are fine, all absent params will default to `None`)
-    )  # type: ignore (missing parameters are fine, all absent params will default to `None`)
+        ),
+    )
     ga4gh_identify(converted_variant_location, in_place="always")
 
     # Build the liftover variant object


### PR DESCRIPTION
As of VRS-Python 2.1.4, these no longer flag for missing arguments (at least not via my local pyright process) so I'm proposing their removal