### PR TITLE
feat: add supported liftover assemblies to /service-info

### DIFF
--- a/src/anyvar/restapi/schema.py
+++ b/src/anyvar/restapi/schema.py
@@ -79,6 +79,12 @@ class ImplMetadata(BaseModel):
     vrs_python_version: str = vrs_python_version
 
 
+class CapabilitiesMetadata(BaseModel):
+    """Define substructure for reporting metadata about service capabilities"""
+
+    liftover_assemblies: list[str] = ["GRCh38", "GRCh37"]
+
+
 class ServiceInfo(BaseModel):
     """Define response structure for GA4GH /service_info endpoint."""
 
@@ -120,6 +126,7 @@ class ServiceInfo(BaseModel):
     version: str = __version__
     spec_metadata: SpecMetadata = SpecMetadata()
     impl_metadata: ImplMetadata = ImplMetadata()
+    capabilities_metadata: CapabilitiesMetadata = CapabilitiesMetadata()
 
 
 class GetSequenceLocationResponse(BaseModel):

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -1,6 +1,6 @@
 """Check basic functions of general endpoint(s)"""
 
-# from http import HTTPStatus
+import re
 from pathlib import Path
 
 import jsonschema
@@ -22,3 +22,15 @@ def test_service_info(client: TestClient, test_data_dir: Path):
     resolver = jsonschema.RefResolver.from_schema(spec)
     data = response.json()
     jsonschema.validate(instance=data, schema=resp_schema, resolver=resolver)
+
+    # test extra metadata
+    assert re.match(r"^2\.\d+\.\d+.?$", data["spec_metadata"]["vrs_version"]), (
+        "VRS version is 2.x"
+    )
+    assert re.match(r"^2\.\d+\.\d+.?$", data["impl_metadata"]["vrs_python_version"]), (
+        "VRS-Python version is 2.x"
+    )
+    assert sorted(data["capabilities_metadata"]["liftover_assemblies"]) == [
+        "GRCh37",
+        "GRCh38",
+    ]


### PR DESCRIPTION
close #283 

updated service-info looks like this -- I'm not thrilled about the field name

```json
{
  "id": "org.biocommons.anyvar",
  "name": "AnyVar",
  "type": {
    "group": "org.biocommons",
    "artifact": "anyvar",
    "version": "unknown"
  },
  "description": "Register and retrieve GA4GH VRS variations and associated annotations.",
  "organization": {
    "name": "bioccommons",
    "url": "https://biocommons.org"
  },
  "contactUrl": "mailto:alex.wagner@nationwidechildrens.org",
  "documentationUrl": "https://github.com/biocommons/anyvar",
  "createdAt": "2025-06-01T00:00:00Z",
  "updatedAt": "2025-06-01T00:00:00Z",
  "environment": "dev",
  "version": "unknown",
  "spec_metadata": {
    "vrs_version": "2.0.1"
  },
  "impl_metadata": {
    "vrs_python_version": "2.1.4"
  },
  "capabilities_metadata": {
    "liftover_assemblies": [
      "GRCh38",
      "GRCh37"
    ]
  }
}
```

once #285 is merged, the new `Assembly` enum could also be used to provide these values