### PR TITLE
test: use test db for celery worker and fix async timing issue

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 
 import pytest
+from dotenv import load_dotenv
 from fastapi.testclient import TestClient
 from ga4gh.vrs import models
 from pydantic import BaseModel
@@ -13,6 +14,15 @@ from anyvar.storage.base_storage import Storage
 from anyvar.translate.translate import _Translator
 
 pytest_plugins = ("celery.contrib.pytest",)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def load_env():
+    """Load `.env` file.
+
+    Must set `autouse=True` to run before other fixtures or test cases.
+    """
+    load_dotenv()
 
 
 @pytest.fixture(scope="session")
@@ -70,17 +80,25 @@ def celery_config():
     }
 
 
+@pytest.fixture(scope="session")
+def storage_uri() -> str:
+    """Define test storage URI to employ for all storage instance fixtures
+
+    Uses `ANYVAR_TEST_STORAGE_URI` env var
+    """
+    return os.environ.get(
+        "ANYVAR_TEST_STORAGE_URI",
+        "postgresql://postgres:postgres@localhost:5432/anyvar_test",
+    )
+
+
 @pytest.fixture(scope="module")
-def storage():
+def storage(storage_uri: str):
     """Provide live storage instance from factory.
 
     Configures from env var ``ANYVAR_TEST_STORAGE_URI``. Defaults to a Postgres DB
     named ``anyvar_test``
     """
-    storage_uri = os.environ.get(
-        "ANYVAR_TEST_STORAGE_URI",
-        "postgresql://postgres:postgres@localhost:5432/anyvar_test",
-    )
     storage = create_storage(uri=storage_uri)
     storage.wipe_db()
     return storage

--- a/tests/integration/vcf/test_annotate_vcf.py
+++ b/tests/integration/vcf/test_annotate_vcf.py
@@ -186,10 +186,15 @@ def test_vcf_registration_async(
     assert "run_id" in resp.json()
     assert resp.json()["run_id"] == vcf_run_id
 
-    time.sleep(5)
+    while True:
+        resp = restapi_client.get(f"/vcf/{vcf_run_id}")
+        if resp.status_code == HTTPStatus.ACCEPTED:
+            time.sleep(1)
+        elif resp.status_code == HTTPStatus.OK:
+            break
+        else:
+            raise AssertionError(f"Unexpected HTTP response: {resp.status_code}")
 
-    resp = restapi_client.get(f"/vcf/{vcf_run_id}")
-    assert resp.status_code == HTTPStatus.OK
     assert (
         b"VRS_Allele_IDs=ga4gh:VA.ryPubD68BB0D-D78L_kK4993mXmsNNWe,ga4gh:VA._QhHH18HBAIeLos6npRgR-S_0lAX5KR6"
         in resp.content

--- a/tests/integration/vcf/test_ingest_vcf.py
+++ b/tests/integration/vcf/test_ingest_vcf.py
@@ -232,10 +232,14 @@ def test_registration_async(
     assert "run_id" in resp.json()
     assert resp.json()["run_id"] == vcf_run_id
 
-    time.sleep(5)
-
-    resp = restapi_client.get(f"/vcf/{vcf_run_id}")
-    assert resp.status_code == HTTPStatus.OK
+    while True:
+        resp = restapi_client.get(f"/vcf/{vcf_run_id}")
+        if resp.status_code == HTTPStatus.ACCEPTED:
+            time.sleep(1)
+        elif resp.status_code == HTTPStatus.OK:
+            break
+        else:
+            raise AssertionError(f"Unexpected HTTP response: {resp.status_code}")
     assert resp.json()["status"] == "SUCCESS"
 
     resp = restapi_client.put(


### PR DESCRIPTION
* call `load_dotenv()` before tests run so that `.env` values are always available
* use pytest-mock to make the celery worker use the test DB connection string (as far as I can tell, it is not otherwise injectable)
* fix an issue with the VCF tests where, for whatever reason, the `time.sleep` call didn't give enough time to process the VCF. In most cases, these test cases will now run much faster because they poll every 1 second instead of always waiting 5 seconds.
* fix an issue with the celery test cleanup where, if there was an early failure and the temporary work dir never gets created, then the cleanup function to remove it throws an additional error