### PR TITLE
chore: add other dependency groups to develop target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ venv/%:
 #=> develop: install package in develop mode
 .PHONY: develop
 develop:
-	pip install -e .[dev,test]
+	pip install -e .[postgres,queueing,test,dev,docs]
 
 #=> devready: create venv, install prerequisites, install pkg in develop mode
 .PHONY: devready


### PR DESCRIPTION
not really a big fan of the whole makefile thing, but if it's here, the `develop` target should probably include all dependency groups