### PR TITLE
style: allow unused args/kwargs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,9 @@ ignore = [
     "RET504",
 ]
 
+[tool.ruff.lint.flake8-unused-arguments]
+ignore-variadic-names = true
+
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "E402"]
 "src/anyvar/restapi/main.py" = ["B008"]

--- a/src/anyvar/extras/vcf.py
+++ b/src/anyvar/extras/vcf.py
@@ -32,7 +32,7 @@ class VcfRegistrar(VcfAnnotator):
         self,
         vcf_coords: str,  # noqa: ARG002
         vrs_allele: vrs_models.Allele,
-        **kwargs,  # noqa: ARG002
+        **kwargs,
     ) -> vrs_models.Allele | None:
         self.av.put_object(vrs_allele)
         return vrs_allele

--- a/src/anyvar/queueing/celery_worker.py
+++ b/src/anyvar/queueing/celery_worker.py
@@ -125,7 +125,7 @@ def exit_task() -> None:
 
 
 @celery.signals.worker_shutting_down.connect
-def on_worker_shutting_down(**kwargs) -> None:  # noqa: ARG001
+def on_worker_shutting_down(**kwargs) -> None:
     """On the `worker_shutting_down` signal, set the cleanup flag and attempt tear down.
     This signal is dispatched in both the prefork and threads pool types on the main process.
     """
@@ -139,7 +139,7 @@ def on_worker_shutting_down(**kwargs) -> None:  # noqa: ARG001
 
 
 @celery.signals.worker_process_shutdown.connect
-def on_worker_process_shutdown(**kwargs) -> None:  # noqa: ARG001
+def on_worker_process_shutdown(**kwargs) -> None:
     """On the `worker_process_shutdown` signal, set the cleanup flag and attempt tear down.
     This signal is dispatched in the forked worker processes in the prefork pool.
     """
@@ -153,7 +153,7 @@ def on_worker_process_shutdown(**kwargs) -> None:  # noqa: ARG001
 
 
 @celery.signals.worker_shutdown.connect
-def on_worker_shutdown(**kwargs) -> None:  # noqa: ARG001
+def on_worker_shutdown(**kwargs) -> None:
     """On the `worker_shutdown` signal, set the cleanup flag and attempt tear down.
     This signal is dispatched in both the prefork and threads pool types on the main process.
     """
@@ -299,7 +299,7 @@ def ingest_annotated_vcf(
 
 
 @celery.signals.after_task_publish.connect
-def update_sent_state(sender: str | None, headers: dict | None, **kwargs) -> None:  # noqa: ARG001
+def update_sent_state(sender: str | None, headers: dict | None, **kwargs) -> None:
     """On the `after_task_publish` signal, set the task status to SENT.  This enables
     the application to differentiate between task ids that are not complete and those
     that do not exist.


### PR DESCRIPTION
I originally did this in #271 but it's not really related. There are a few places where we have unused `**kwargs**` for API compatibility reasons and they should not be ARG001 violations.