### PR TITLE
feat: use enum for molecule_type in sequence_references table

### DIFF
--- a/src/anyvar/storage/orm.py
+++ b/src/anyvar/storage/orm.py
@@ -13,7 +13,6 @@ from sqlalchemy import (
     UniqueConstraint,
     create_engine,
 )
-from sqlalchemy.dialects.postgresql import ENUM as PgEnum  # noqa: N811
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import (
     DeclarativeBase,
@@ -143,8 +142,10 @@ class SequenceReference(Base):
     molecule_type: Mapped[MoleculeType | None] = mapped_column(
         Enum(
             MoleculeType,
+            name="molecule_type",
             native_enum=True,
             values_callable=lambda mt_enum: [mt.value for mt in mt_enum],
+            validate_strings=True,
         )
     )
 
@@ -168,9 +169,10 @@ class Annotation(Base):
     )
 
 
-mapping_type_enum = PgEnum(
+mapping_type_enum = Enum(
     VariationMappingType,
     name="mapping_type",
+    native_enum=True,
     metadata=Base.metadata,
     create_type=True,
     validate_strings=True,


### PR DESCRIPTION
close #311

```shell
anyvar=# \dT+ moleculetype;
                                         List of data types
 Schema |     Name     | Internal name | Size | Elements | Owner  | Access privileges | Description 
--------+--------------+---------------+------+----------+--------+-------------------+-------------
 public | moleculetype | moleculetype  | 4    | genomic +| anyvar |                   | 
        |              |               |      | RNA     +|        |                   | 
        |              |               |      | mRNA    +|        |                   | 
        |              |               |      | protein  |        |                   | 
(1 row)

anyvar=# INSERT INTO sequence_references (id, molecule_type) VALUES ('id', 'protein');
INSERT 0 1
anyvar=# INSERT INTO sequence_references (id, molecule_type) VALUES ('id', 'PROTEIN');
ERROR:  invalid input value for enum moleculetype: "PROTEIN"
LINE 2: VALUES ('id', 'PROTEIN');
```