### PR TITLE
ci: add pypi release workflow (using trusted publisher)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
close #135

I know I said in the issue to use biocommons template, but IMO I think we should stick with what's in GML software-templates (which uses trusted publisher)