### PR TITLE
chore: clean up translate return type

### DIFF
--- a/src/anyvar/translate/translate.py
+++ b/src/anyvar/translate/translate.py
@@ -27,7 +27,7 @@ class Translator(ABC):
     dp: _DataProxy
 
     @abstractmethod
-    def translate_variation(self, var: str, **kwargs) -> VrsVariation | None:
+    def translate_variation(self, var: str, **kwargs) -> VrsVariation:
         """Translate provided variation text into a VRS Variation object.
 
         :param var: user-provided string describing or referencing a variation.
@@ -43,7 +43,7 @@ class Translator(ABC):
                 Defaults to "GRCh38". Must be "GRCh38" or "GRCh7"
                 VRS-Python sets a default, but we should set a default just in case
                 VRS-Python ever changes the default.
-        :returns: VRS variation object if able to translate
+        :returns: VRS variation object
         :raises TranslationError: if translation is unsuccessful, either because
             the submitted variation is malformed, or because VRS-Python doesn't support
             its translation.

--- a/src/anyvar/translate/vrs_python.py
+++ b/src/anyvar/translate/vrs_python.py
@@ -39,7 +39,7 @@ class VrsPythonTranslator(Translator):
         self.allele_tlr = AlleleTranslator(data_proxy=self.dp)
         self.cnv_tlr = CnvTranslator(data_proxy=self.dp)
 
-    def translate_variation(self, var: str, **kwargs) -> types.VrsVariation | None:
+    def translate_variation(self, var: str, **kwargs) -> types.VrsVariation:
         """Translate provided variation text into a VRS Variation object.
 
         :param var: user-provided string describing or referencing a variation.
@@ -50,12 +50,11 @@ class VrsPythonTranslator(Translator):
         :keyword models.CopyChange copy_change: The EFO code for VRS COpy Number Change
         :keyword ReferenceAssembly assembly_name: Assembly name for ``var``.
             Only used when ``var`` uses gnomad format.
-        :returns: VRS variation object if able to translate
+        :returns: VRS variation object
         :raises TranslationError: if translation is unsuccessful, either because
             the submitted variation is malformed, or because VRS-Python doesn't support
             its translation.
         """
-        variation = None
         input_type = kwargs.get("input_type")
         if input_type == types.SupportedVariationType.ALLELE:
             variation = self.translate_allele(var, **kwargs)


### PR DESCRIPTION
This was marked as being optional, but in actuality, a TranslationError would be raised, so this fixes up the type annotation to match behavior