### PR TITLE
Change db column name mapping for location to avoid ANSI SQL reserved words

### DIFF
--- a/src/anyvar/storage/orm.py
+++ b/src/anyvar/storage/orm.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
     String,
     UniqueConstraint,
     create_engine,
+    inspect,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import (
@@ -45,9 +46,8 @@ class Base(DeclarativeBase):
 
     def to_dict(self) -> dict:
         """Convert the model fields to a dictionary (non-recursive)."""
-        return {
-            column.name: getattr(self, column.name) for column in self.__table__.columns
-        }
+        mapper = inspect(self.__class__)
+        return {column.key: getattr(self, column.key) for column in mapper.column_attrs}
 
     def get_disassembler(self) -> Iterator["Base"]:
         """Yields an Iterator that recursively disassembles this entity into itself + its constituent ORM objects.


### PR DESCRIPTION
The `Location` entity has a `start` column.  `START` is a reserved word in ANSI SQL and better avoided.

Map `start` and `end` to `start_pos` and `end_pos` columns in the database to avoid reserved words.