### PR TITLE
chore: add citation file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -31,4 +31,7 @@ authors:
   - family-names: Wagner
     given-names: Alex
     orcid: https://orcid.org/0000-0002-2502-8961
+# identifiers:
+#   - type: doi
+#     value: fill in from zenodo when available
 url: "https://github.com/biocommons/anyvar"


### PR DESCRIPTION
* purposely omitting version and date released so Zenodo can fill that in itself
* including author names so that we can specify ORCiD IDs, I guess?