### PR TITLE
feat!: add indexes to location positions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -50,6 +50,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Wait for Postgres
+        run: |
+          for i in {1..30}; do
+            pg_isready -h localhost -p 5432 -U postgres && exit 0
+            sleep 1
+          done
+          exit 1
+
+      - name: Initialize GiST extension
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -p 5432 -U postgres -d postgres \
+            -c "CREATE EXTENSION IF NOT EXISTS btree_gist;"
+
       - name: Cache chainfiles for liftover
         uses: actions/cache@v4
         with:

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -26,7 +26,13 @@ Some configuration is required to run tests:
 
     Ensure that the database and role are available in the PostgreSQL instance.
 
-    For example, to support the connection string ``"postgresql://anyvar_test_user:anyvar_test_pw@localhost:5432/anyvar_test_db"``, run ``psql -U postgres -C "CREATE USER anyvar_test_user WITH PASSWORD anyvar_test_pw; CREATE DATABASE anyvar_test_db WITH OWNER anyvar_test_user;"``
+    For example, to support the connection string ``"postgresql://anyvar_test_user:anyvar_test_pw@localhost:5432/anyvar_test_db"``, run
+
+    .. code-block:: shell
+
+        psql -U postgres -c "CREATE USER anyvar_test_user WITH PASSWORD 'anyvar_test_pw';"
+        psql -U postgres -c "CREATE DATABASE anyvar_test_db WITH OWNER anyvar_test_user;"
+        psql -U postgres -d anyvar_test_db -c "CREATE EXTENSION IF NOT EXISTS btree_gist;"
 
 * **Ensure Celery backend and broker are available, and that Celery workers are NOT running** - the task queueing tests create and manage their own Celery workers, but they do require access to a broker/backend for message transport and result storage. See `async task queuing setup instructions <todo>`_ for more. If an existing AnyVar Celery worker is running, they may not function properly.
 

--- a/docs/source/getting_started/manual_setup.rst
+++ b/docs/source/getting_started/manual_setup.rst
@@ -6,7 +6,7 @@ More advanced users may want to tailor resources to their specific needs. This s
 Prerequisites
 =============
 
-* Python >= 3.10
+* Python >= 3.11
 * PostgreSQL
 * Redis, or another `Celery backend/broker <https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/index.html>`_
 
@@ -28,7 +28,9 @@ AnyVar utilizes the connection string defined by the environment variable ``ANYV
 
 .. code-block:: console
 
-   % psql -U postgres -C "CREATE USER anyvar WITH PASSWORD 'anyvar-pw'; CREATE DATABASE anyvar WITH OWNER anyvar;"
+   % psql -U postgres -c "CREATE USER anyvar WITH PASSWORD 'anyvar-pw';"
+   % psql -U postgres -c "CREATE DATABASE anyvar WITH OWNER anyvar;"
+   % psql -U postgres -d anyvar -c "CREATE EXTENSION IF NOT EXISTS btree_gist;"
    % export ANYVAR_STORAGE_URI="postgresql://anyvar:anyvar-pw@localhost:5432/anyvar"
 
 See more on storage configuration :doc:`here <../configuration/storage>`.

--- a/src/anyvar/restapi/main.py
+++ b/src/anyvar/restapi/main.py
@@ -676,9 +676,22 @@ async def add_registration_annotations(
 )
 def search_variations(
     request: Request,
-    accession: Annotated[str, Query(..., description="Sequence accession identifier")],
-    start: Annotated[int, Query(..., description="Start position for genomic region")],
-    end: Annotated[int, Query(..., description="End position for genomic region")],
+    accession: Annotated[
+        str,
+        Query(
+            ...,
+            description='Sequence accession identifier (ex: "ga4gh:SQ.8_liLu1aycC0tPQPFmUaGXJLDs5SbPZ5")',
+            examples=["ga4gh:SQ.8_liLu1aycC0tPQPFmUaGXJLDs5SbPZ5"],
+        ),
+    ],
+    start: Annotated[
+        int,
+        Query(..., description="Start position for genomic region", examples=[2781631]),
+    ],
+    end: Annotated[
+        int,
+        Query(..., description="End position for genomic region", examples=[2781758]),
+    ],
 ) -> SearchResponse:
     """Fetch all registered variations within the provided genomic coordinates.
 

--- a/src/anyvar/storage/orm.py
+++ b/src/anyvar/storage/orm.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     String,
     UniqueConstraint,
     create_engine,
+    func,
     inspect,
 )
 from sqlalchemy.dialects.postgresql import JSONB
@@ -90,21 +91,21 @@ class Base(DeclarativeBase):
 
         Example:
         >>> sequence_reference = orm.SequenceReference(
-            id="SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO",
-            # etc...
-        )
+        ...     id="SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO",
+        ...     # etc...
+        ... )
         >>> location = orm.Location(
-            id="ga4gh:SL.U8b3eMCw6QjGA9cnDx_KYxqbol0UrEKx",
-            sequence_reference_id=sequence_reference.id,
-            sequence_reference=sequence_reference
-            # etc...
-        )
+        ...     id="ga4gh:SL.U8b3eMCw6QjGA9cnDx_KYxqbol0UrEKx",
+        ...     sequence_reference_id=sequence_reference.id,
+        ...     sequence_reference=sequence_reference,
+        ...     # etc...
+        ... )
         >>> allele = orm.Allele(
-            id="ga4gh:VA.uR23Z7AAFaLHhPUymUEYNG4o2CCE560T",
-            location_id=location.id,
-            location=location
-            # etc...
-        )
+        ...     id="ga4gh:VA.uR23Z7AAFaLHhPUymUEYNG4o2CCE560T",
+        ...     location_id=location.id,
+        ...     location=location,
+        ...     # etc...
+        ... )
         >>> disassembled_allele = allele.disassemble()
         >>> print(disassembled_allele)
         {'Allele': <anyvar.storage.orm.Allele object at 0x108dfa780>, 'Location': <anyvar.storage.orm.Location object at 0x101416db0>, 'SequenceReference': <anyvar.storage.orm.SequenceReference object at 0x100af5250>}
@@ -164,6 +165,22 @@ class Location(Base):
         yield self
         yield self.sequence_reference
 
+    @declared_attr
+    @classmethod
+    def __table_args__(cls):  # noqa: ANN206
+        uri = os.environ.get("ANYVAR_STORAGE_URI", DEFAULT_STORAGE_URI)
+        parsed_uri = urlparse(uri)
+        if parsed_uri.scheme == "snowflake":
+            return ()
+        return (
+            Index(
+                "ix_location_ref_overlap",
+                cls.sequence_reference_id,
+                func.int8range(cls.start, cls.end, "[]"),
+                postgresql_using="gist",
+            ),
+        )
+
 
 class Allele(Base):
     """AnyVar ORM model for Alleles"""
@@ -195,7 +212,6 @@ class Annotation(Base):
         .with_variant(SnowflakeVARIANT, "snowflake")
     )
 
-    # https://docs.sqlalchemy.org/en/20/core/constraints.html#indexes
     @declared_attr
     @classmethod
     def __table_args__(cls):  # noqa: ANN206
@@ -265,9 +281,9 @@ def session_factory(db_url: str) -> sessionmaker:
 
     >>> sf = session_factory(db_url)
     >>> with sf() as session:
-    >>>     with session.begin(): # Perform database operations
-    >>>         session.add(some_object)
-    >>>         session.execute(some_query)
+    ...     with session.begin():  # Perform database operations
+    ...         session.add(some_object)
+    ...         session.execute(some_query)
     >>> # Transaction from session.begin() automatically commits if no exceptions occur
     >>> # Session automatically closes
 

--- a/src/anyvar/storage/postgres.py
+++ b/src/anyvar/storage/postgres.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from collections.abc import Iterable
 
 from ga4gh.vrs import models as vrs_models
-from sqlalchemy import create_engine, delete, select
+from sqlalchemy import create_engine, delete, func, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload, sessionmaker
@@ -393,8 +393,9 @@ class PostgresObjectStore(Storage):
                 .join(orm.SequenceReference)
                 .where(
                     orm.SequenceReference.id == refget_accession,
-                    orm.Location.start <= stop,
-                    orm.Location.end >= start,
+                    func.int8range(orm.Location.start, orm.Location.end, "[]").op("&&")(
+                        func.int8range(start, stop, "[]")
+                    ),
                 )
                 .limit(self.MAX_ROWS)
             )


### PR DESCRIPTION
close #371

The bottleneck here is this part

```
                .where(
                    orm.Location.start <= stop,
                    orm.Location.end >= start,
                )
```

Basically, normal b-trees aren't really suited for determining the overlap of two inequalities in opposite directions. Postgres provides the `GiST`, or Generalized Search Tree, which comes with a native operation to perform this kind of lookup. See https://www.postgresql.org/docs/current/gist.html

One sticking point is that, after running `createdb`, you also need to initialize the GiST extension with `CREATE EXTENSION IF NOT EXISTS btree_gist;`. This is annoying.


* I also added examples to the search API route because I kept forgetting what the legal `accession` value format was. I included both a text example (so that it's visible in the swaggerui) and an `examples` arg for the jsonschema.