### PR TITLE
feat: delete variants

### DIFF
--- a/src/anyvar/anyvar.py
+++ b/src/anyvar/anyvar.py
@@ -178,16 +178,16 @@ class AnyVar:
         :param object_id: ID of object to delete
         :raise ObjectNotFoundError: if no stored object matches given ID
         """
+        try:
+            vrs_object = self._get_object_polymorphic(object_id)
+        except KeyError as e:
+            raise ObjectNotFoundError from e
         for annotation in self.object_store.get_annotations(object_id):
             self.object_store.delete_annotation(annotation)
         for mapping in self.object_store.get_mappings(object_id, as_source=True):
             self.object_store.delete_mapping(mapping)
         for mapping in self.object_store.get_mappings(object_id, as_source=False):
             self.object_store.delete_mapping(mapping)
-        try:
-            vrs_object = self._get_object_polymorphic(object_id)
-        except KeyError as e:
-            raise ObjectNotFoundError from e
         object_type = objects.vrs_object_class_map[vrs_object.type]
         self.object_store.delete_objects(object_type, [object_id])
 

--- a/src/anyvar/anyvar.py
+++ b/src/anyvar/anyvar.py
@@ -83,7 +83,7 @@ def has_queueing_enabled() -> bool:
 
 
 class ObjectNotFoundError(Exception):
-    """Raised when a related object is requested for a primary entity that does not exist."""
+    """Raised when an ID is given for a non-existent object."""
 
 
 class AnyVar:
@@ -169,6 +169,27 @@ class AnyVar:
                 # Continue to next object type
                 continue
         raise KeyError(f"Object {object_id} not found in any table")
+
+    def delete_object(self, object_id: str) -> None:
+        """Delete an object and associated mappings/annotations by ID
+
+        Doesn't delete wrapped objects (e.g. deleting a variant won't delete the associated location)
+
+        :param object_id: ID of object to delete
+        :raise ObjectNotFoundError: if no stored object matches given ID
+        """
+        for annotation in self.object_store.get_annotations(object_id):
+            self.object_store.delete_annotation(annotation)
+        for mapping in self.object_store.get_mappings(object_id, as_source=True):
+            self.object_store.delete_mapping(mapping)
+        for mapping in self.object_store.get_mappings(object_id, as_source=False):
+            self.object_store.delete_mapping(mapping)
+        try:
+            vrs_object = self._get_object_polymorphic(object_id)
+        except KeyError as e:
+            raise ObjectNotFoundError from e
+        object_type = objects.vrs_object_class_map[vrs_object.type]
+        self.object_store.delete_objects(object_type, [object_id])
 
     def put_annotation(self, annotation: metadata.Annotation) -> int | None:
         """Attempt to store an annotation.

--- a/src/anyvar/restapi/objects_router.py
+++ b/src/anyvar/restapi/objects_router.py
@@ -355,7 +355,6 @@ def delete_object_by_id(
         av.delete_object(vrs_id)
     except ObjectNotFoundError as e:
         raise HTTPException(status_code=HTTPStatus.NOT_FOUND) from e
-    raise NotImplementedError
 
 
 @objects_router.post(

--- a/src/anyvar/restapi/objects_router.py
+++ b/src/anyvar/restapi/objects_router.py
@@ -342,8 +342,8 @@ def get_object_by_id(
     "/object/{vrs_id}",
     response_model_exclude_none=True,
     operation_id="deleteObject",
-    summary="Delete a VRS object",
-    description="Attempt deletion of a VRS object by its ID.",
+    summary="Delete a VRS object and any associated mappings and annotations",
+    description="Attempt deletion of a VRS object by its ID. Mappings and annotations that reference this object will also be deleted.",
 )
 def delete_object_by_id(
     request: Request,

--- a/src/anyvar/restapi/objects_router.py
+++ b/src/anyvar/restapi/objects_router.py
@@ -338,6 +338,26 @@ def get_object_by_id(
     return GetObjectResponse(messages=[], data=vrs_object)
 
 
+@objects_router.delete(
+    "/object/{vrs_id}",
+    response_model_exclude_none=True,
+    operation_id="deleteObject",
+    summary="Delete a VRS object",
+    description="Attempt deletion of a VRS object by its ID.",
+)
+def delete_object_by_id(
+    request: Request,
+    vrs_id: Annotated[StrictStr, Path(..., description="ID of object to delete")],
+) -> None:
+    """Delete a VRS object."""
+    av: AnyVar = request.app.state.anyvar
+    try:
+        av.delete_object(vrs_id)
+    except ObjectNotFoundError as e:
+        raise HTTPException(status_code=HTTPStatus.NOT_FOUND) from e
+    raise NotImplementedError
+
+
 @objects_router.post(
     "/object/{vrs_id}/annotations",
     response_model_exclude_none=True,

--- a/tests/integration/restapi/objects_router/test_variation.py
+++ b/tests/integration/restapi/objects_router/test_variation.py
@@ -224,23 +224,12 @@ def test_delete_object_and_mappings(restapi_client: TestClient, alleles: dict):
     # check that everything's gone
     response = restapi_client.get(f"/object/{allele_id}")
     assert response.status_code == HTTPStatus.NOT_FOUND
-    response = restapi_client.get(
-        f"/object/{allele_id}/mappings/liftover_to?as_source=true"
-    )
-    assert response.json() == {
-        "detail": "VRS Object ga4gh:VA.d6ru7RcuVO0-v3TtPFX5fZz-GLQDhMVb not found"
-    }
-    response = restapi_client.get(
-        f"/object/{allele_id}/mappings/liftover_to?as_source=false"
-    )
-
-    assert response.json() == {
-        "detail": "VRS Object ga4gh:VA.d6ru7RcuVO0-v3TtPFX5fZz-GLQDhMVb not found"
-    }
-    response = restapi_client.get(
-        f"/object/{allele_id}/annotations/clinvar_somatic_classification"
-    )
-
-    assert response.json() == {
-        "detail": "VRS Object ga4gh:VA.d6ru7RcuVO0-v3TtPFX5fZz-GLQDhMVb not found"
-    }
+    for request_path in (
+        f"/object/{allele_id}/mappings/liftover_to?as_source=true",
+        f"/object/{allele_id}/mappings/liftover_to?as_source=false",
+        f"/object/{allele_id}/annotations/clinvar_somatic_classification",
+    ):
+        response = restapi_client.get(request_path)
+        assert response.json() == {
+            "detail": "VRS Object ga4gh:VA.d6ru7RcuVO0-v3TtPFX5fZz-GLQDhMVb not found"
+        }

--- a/tests/integration/restapi/objects_router/test_variation.py
+++ b/tests/integration/restapi/objects_router/test_variation.py
@@ -194,3 +194,44 @@ def test_post_variation_invalid_request(
     resp = restapi_client.post("/variation", json={"definition": definition})
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
     assert resp.json() == {"detail": err_msg}
+
+
+def test_simple_delete_object(restapi_client: TestClient, alleles: dict):
+    for allele_fixture in alleles.values():
+        restapi_client.put("/vrs_variation", json=allele_fixture["variation"])
+    for allele_id in alleles:
+        restapi_client.delete(f"/objects/{allele_id}")
+
+
+def test_delete_object_and_mappings(restapi_client: TestClient, alleles: dict):
+    allele_id = "ga4gh:VA.d6ru7RcuVO0-v3TtPFX5fZz-GLQDhMVb"
+    allele = alleles[allele_id]["variation"]
+    response = restapi_client.put("/vrs_variation", json=allele)
+    response.raise_for_status()
+    response = restapi_client.post(
+        f"/object/{allele_id}/annotations",
+        json={
+            "annotation_type": "clinvar_somatic_classification",
+            "annotation_value": "Oncogenic",
+        },
+    )
+    response.raise_for_status()
+
+    # attempt deletion
+    response = restapi_client.delete(f"/objects/{allele_id}")
+
+    # check that everything's gone
+    response = restapi_client.get(f"/object/{allele_id}")
+    assert response.status_code == HTTPStatus.NOT_FOUND
+    response = restapi_client.get(
+        f"/object/{allele_id}/mappings/liftover_to?as_source=true"
+    )
+    assert response.json() == []
+    response = restapi_client.get(
+        f"/object/{allele_id}/mappings/liftover_to?as_source=false"
+    )
+    assert response.json() == []
+    response = restapi_client.get(
+        f"/object/{allele_id}/annotations/clinvar_somatic_classification"
+    )
+    assert response.json() == []

--- a/tests/integration/restapi/objects_router/test_variation.py
+++ b/tests/integration/restapi/objects_router/test_variation.py
@@ -218,7 +218,8 @@ def test_delete_object_and_mappings(restapi_client: TestClient, alleles: dict):
     response.raise_for_status()
 
     # attempt deletion
-    response = restapi_client.delete(f"/objects/{allele_id}")
+    response = restapi_client.delete(f"/object/{allele_id}")
+    response.raise_for_status()
 
     # check that everything's gone
     response = restapi_client.get(f"/object/{allele_id}")
@@ -226,12 +227,20 @@ def test_delete_object_and_mappings(restapi_client: TestClient, alleles: dict):
     response = restapi_client.get(
         f"/object/{allele_id}/mappings/liftover_to?as_source=true"
     )
-    assert response.json() == []
+    assert response.json() == {
+        "detail": "VRS Object ga4gh:VA.d6ru7RcuVO0-v3TtPFX5fZz-GLQDhMVb not found"
+    }
     response = restapi_client.get(
         f"/object/{allele_id}/mappings/liftover_to?as_source=false"
     )
-    assert response.json() == []
+
+    assert response.json() == {
+        "detail": "VRS Object ga4gh:VA.d6ru7RcuVO0-v3TtPFX5fZz-GLQDhMVb not found"
+    }
     response = restapi_client.get(
         f"/object/{allele_id}/annotations/clinvar_somatic_classification"
     )
-    assert response.json() == []
+
+    assert response.json() == {
+        "detail": "VRS Object ga4gh:VA.d6ru7RcuVO0-v3TtPFX5fZz-GLQDhMVb not found"
+    }


### PR DESCRIPTION
close #424 

`DELETE /object/{vrs_id}`

* `200 OK` with empty response if successful. First deletes associated mappings/annotations then the object itself.
* `404 NOT FOUND` if no object associated w/ VRS ID

This ended up being relatively smooth based on what's already available in the storage classes. The only awkward part is that you effectively have to do a lookup on 1-3 different tables to figure out the type of an object. It occurs to me that maybe we should be enforcing the VRS ID as a marker for the object type and/or providing different routes for different kinds of resources. But whatever.

An alternative I considered would be to have the storage class's `delete_objects()` class return the # of affected rows, so instead of running a lookup to deduce object type, you could just attempt deletions and if none of them work, then the object must not have existed. However, that's an interface change, so I didn't necessarily want to go that route.