### PR TITLE
feat: delete extensions

### DIFF
--- a/src/anyvar/anyvar.py
+++ b/src/anyvar/anyvar.py
@@ -213,7 +213,7 @@ class AnyVar:
         except KeyError as e:
             raise ObjectNotFoundError from e
         for extension in self.object_store.get_extensions(object_id):
-            self.object_store.delete_extension(extension)
+            self.object_store.delete_extensions(vrs_object.id, extension.name)
         for mapping in self.object_store.get_mappings(object_id, as_source=True):
             self.object_store.delete_mapping(mapping)
         for mapping in self.object_store.get_mappings(object_id, as_source=False):
@@ -242,6 +242,29 @@ class AnyVar:
             except KeyError as e:
                 raise ObjectNotFoundError(object_id) from e
         return extensions
+
+    def delete_object_extensions(
+        self, object_id: str, extension_name: str | None = None
+    ) -> None:
+        """Delete extensions
+
+         * If no ``extension_name`` is given, delete all associated extensions.
+         * Delete all instances of extensions by the given name
+
+        :param object_id: object ID to delete extensions for
+        :param extension_name: optionally, the name of extensions to delete
+        :raise ObjectNotFoundError: if ``object_id`` can't be found in DB
+        """
+        try:
+            rowcount = self.object_store.delete_extensions(object_id, extension_name)
+        except Exception as e:
+            _logger.exception("Failed to retrieve extensions for object: %s", object_id)
+            raise e  # noqa: TRY201
+        if not rowcount:
+            try:
+                _ = self.get_object(object_id)
+            except KeyError as e:
+                raise ObjectNotFoundError(object_id) from e
 
     def create_timestamp_if_missing(self, object_id: str) -> int | None:
         """Store a 'creation_timestamp' extension if missing for an object

--- a/src/anyvar/restapi/objects_router.py
+++ b/src/anyvar/restapi/objects_router.py
@@ -4,7 +4,7 @@ import logging
 from http import HTTPStatus
 from typing import Annotated
 
-from fastapi import APIRouter, Body, HTTPException, Query, Request
+from fastapi import APIRouter, Body, HTTPException, Query, Request, Response
 from fastapi.params import Path
 from pydantic import StrictStr
 
@@ -77,6 +77,7 @@ def add_object_extension(
         AddExtensionRequest,
         Body(
             description="Extension to associate with the variation",
+            example={"name": "source_dataset", "value": "gnomAD_v4.1"},
         ),
     ],
 ) -> AddExtensionResponse:
@@ -133,6 +134,29 @@ def get_object_extensions(
             detail=f"VRS Object {vrs_id} not found",
         ) from e
     return GetExtensionResponse(extensions=extensions)
+
+
+@objects_router.delete(
+    "/object/{vrs_id}/extensions/{extension_name}",
+    response_model_exclude_none=True,
+    summary="Delete extensions for a VRS object.",
+    description="Delete all extensions under a given extension name for a VRS object. Returns idempotently regardless of whether there were extensions under that name for the object. Return 404 NOT FOUND if no known object matches given object ID.",
+    status_code=HTTPStatus.NO_CONTENT,
+)
+def delete_object_extensions(
+    request: Request,
+    vrs_id: Annotated[StrictStr, Path(..., description="VRS ID for VRS Object")],
+    extension_name: Annotated[StrictStr, Path(..., description="Extension name")],
+) -> Response:
+    """Delete extensions associated with a VRS object."""
+    av: AnyVar = request.app.state.anyvar
+    try:
+        av.delete_object_extensions(vrs_id, extension_name)
+    except ObjectNotFoundError as e:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_FOUND, detail=f"Object `{vrs_id}` not found"
+        ) from e
+    return Response(status_code=HTTPStatus.NO_CONTENT)  # blank response if successful
 
 
 @objects_router.put(

--- a/src/anyvar/storage/base.py
+++ b/src/anyvar/storage/base.py
@@ -7,6 +7,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 
 from ga4gh.vrs import models as vrs_models
+from pydantic import JsonValue
 
 from anyvar.core import metadata
 from anyvar.core import objects as anyvar_objects
@@ -179,15 +180,22 @@ class Storage(ABC):
         """
 
     @abstractmethod
-    def delete_extension(self, extension: metadata.Extension) -> None:
-        """Deletes an extension from the database
+    def delete_extensions(
+        self,
+        object_id: str,
+        name: str | None = None,
+        value: JsonValue | None = None,
+    ) -> int:
+        """Delete extension(s) for an object
 
-        * If no such extension exists, do nothing.
-        * Deletes do not cascade.
+        Supports gradual specificity -- either delete all extensions,
+        or delete all extensions under a given key/name, or delete all extensions
+        with a given name AND value.
 
-        :param extension: The extension object to delete
-        :raise DataIntegrityError: if attempting to delete an object which is
-            depended upon by another object
+        :param object_id: The object ID
+        :param name: Optional extension key/name to delete
+        :param value: Optional extension value to delete. Ignored if ``name`` is not provided
+        :return: Number of deleted rows
         """
 
     @staticmethod

--- a/src/anyvar/storage/no_db.py
+++ b/src/anyvar/storage/no_db.py
@@ -6,6 +6,8 @@ writes are discarded and reads always miss.
 
 from collections.abc import Iterable
 
+from pydantic import JsonValue
+
 from anyvar.core import metadata
 from anyvar.core import objects as anyvar_objects
 from anyvar.storage.base import AlleleSearchPage, Storage
@@ -68,8 +70,14 @@ class NoObjectStore(Storage):
         """(No-op) Get all extensions for the specified object, optionally filtered by type."""
         return []
 
-    def delete_extension(self, extension: metadata.Extension) -> None:
-        """(No-op) Deletes an extension from the database"""
+    def delete_extensions(
+        self,
+        object_id: str,
+        name: str | None = None,
+        value: JsonValue | None = None,
+    ) -> int:
+        """(No-op) Delete extension(s) for an object"""
+        return 0
 
     def search_alleles(
         self,

--- a/src/anyvar/storage/postgres.py
+++ b/src/anyvar/storage/postgres.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from collections.abc import Iterable
 
 from ga4gh.vrs import models as vrs_models
+from pydantic import JsonValue
 from sqlalchemy import and_, create_engine, delete, func, or_, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import IntegrityError
@@ -334,22 +335,33 @@ class PostgresObjectStore(Storage):
                 for db_extension in db_extensions
             ]
 
-    def delete_extension(self, extension: metadata.Extension) -> None:
-        """Deletes an extension from the database
+    def delete_extensions(
+        self,
+        object_id: str,
+        name: str | None = None,
+        value: JsonValue | None = None,
+    ) -> int:
+        """Delete extension(s) for an object
 
-        * If no such extension exists, do nothing.
-        * Deletes do not cascade.
+        Supports gradual specificity -- either delete all extensions,
+        or delete all extensions under a given key/name, or delete all extensions
+        with a given name AND value.
 
-        :param extension: The extension object to delete
+        If no extension matching given args exists, do nothing.
+
+        :param object_id: The object ID
+        :param name: Optional extension key/name to delete
+        :param value: Optional extension value to delete. Ignored if ``name`` is not provided
+        :return: Number of deleted rows
         """
-        stmt = (
-            delete(orm.Extension)
-            .where(orm.Extension.object_id == extension.object_id)
-            .where(orm.Extension.name == extension.name)
-            .where(orm.Extension.value == json.dumps(extension.value))
-        )
+        stmt = delete(orm.Extension).where(orm.Extension.object_id == object_id)
+        if name:
+            stmt = stmt.where(orm.Extension.name == name)
+            if value:
+                stmt = stmt.where(orm.Extension.value == json.dumps(value))
         with self.session_factory() as session, session.begin():
-            session.execute(stmt)
+            result = session.execute(stmt)
+            return result.rowcount or 0
 
     def search_alleles(
         self,

--- a/src/anyvar/storage/snowflake.py
+++ b/src/anyvar/storage/snowflake.py
@@ -1,5 +1,6 @@
 """Provide Snowflake-based storage implementation."""
 
+import json
 import logging
 import os
 from collections import defaultdict
@@ -12,6 +13,7 @@ import snowflake.connector
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from ga4gh.vrs import models as vrs_models
+from pydantic import JsonValue
 from snowflake.sqlalchemy import MergeInto
 from snowflake.sqlalchemy.snowdialect import SnowflakeDialect
 from sqlalchemy import (
@@ -617,6 +619,7 @@ class SnowflakeObjectStore(Storage):
         """Deletes an extension from the database
 
         * If no such extension exists, do nothing.
+        * Deletes all exact match cases (ie can delete multiple redundant extensions)
         * Deletes do not cascade.
 
         :param extension: The extension object to delete
@@ -629,6 +632,35 @@ class SnowflakeObjectStore(Storage):
         )
         with self.session_factory() as session, session.begin():
             session.execute(stmt)
+
+    def delete_extensions(
+        self,
+        object_id: str,
+        name: str | None = None,
+        value: JsonValue | None = None,
+    ) -> int:
+        """Delete extension(s) for an object
+
+        Supports gradual specificity -- either delete all extensions,
+        or delete all extensions under a given key/name, or delete all extensions
+        with a given name AND value.
+
+        If no extension matching given args exists, do nothing.
+
+        :param object_id: The object ID
+        :param name: Optional extension key/name to delete
+        :param value: Optional extension value to delete. Ignored if ``name`` is not provided
+        :return: Number of deleted rows
+        """
+        stmt = delete(orm.Extension).where(orm.Extension.object_id == object_id)
+        if name:
+            stmt = stmt.where(orm.Extension.name == name)
+            if value:
+                stmt = stmt.where(orm.Extension.value == json.dumps(value))
+        with self.session_factory() as session, session.begin():
+            result = session.execute(stmt)
+            # not clear to me that this works but I don't have an easy way of testing
+            return max(result.rowcount or 0, 0)
 
     def search_alleles(
         self,

--- a/tests/integration/restapi/objects_router/test_extension.py
+++ b/tests/integration/restapi/objects_router/test_extension.py
@@ -17,6 +17,9 @@ def test_extension_crud(
     preloaded_alleles: dict,  # noqa: ARG001
     braf_extension_payload: dict,
 ):
+    """``preloaded_alleles`` is imported to trigger the side-effect to load them into the DB,
+    but we don't need to access them once they're loaded
+    """
     braf_v600e_id = "ga4gh:VA.Otc5ovrw906Ack087o1fhegB4jDRqCAe"
 
     # post an extension
@@ -36,6 +39,18 @@ def test_extension_crud(
     assert len(data) == 1
     assert data[0]["name"] == braf_extension_payload["name"]
     assert data[0]["value"] == braf_extension_payload["value"]
+
+    # delete it
+    response = restapi_client.delete(
+        f"/object/{braf_v600e_id}/extensions/{braf_extension_payload['name']}"
+    )
+    response.raise_for_status()
+    response = restapi_client.get(
+        f"/object/{braf_v600e_id}/extensions/{braf_extension_payload['name']}"
+    )
+    response.raise_for_status()
+    data = response.json()["extensions"]
+    assert len(data) == 0
 
 
 def test_get_extension_nonexistent_var(restapi_client: TestClient):

--- a/tests/unit/storage/storage_test_funcs.py
+++ b/tests/unit/storage/storage_test_funcs.py
@@ -351,11 +351,11 @@ def run_extensions_crud(
     storage: Storage,
     focus_alleles: tuple[models.Allele, models.Allele, models.Allele],
 ):
-    """Broad coverage of CRUD methods for annotations"""
+    """Broad coverage of CRUD methods for extensions"""
     # prepopulate
     storage.add_objects(focus_alleles)
 
-    # add arbitrary annotations
+    # add arbitrary extensions
     ann1 = metadata.Extension(
         object_id=focus_alleles[0].id,
         name="classification",
@@ -381,7 +381,7 @@ def run_extensions_crud(
     )
     storage.add_extension(ann4)
 
-    # get annotations back
+    # get extensions back
     result = storage.get_extensions(focus_alleles[0].id, "classification")
     assert result == [ann1]
 
@@ -392,7 +392,7 @@ def run_extensions_crud(
     sorted(result, key=lambda i: (i.name, i.value))
     assert result == [ann3, ann4]
 
-    # adding the same annotation multiple times creates redundant rows
+    # adding the same extension multiple times creates redundant rows
     storage.add_extension(ann4)
     result = storage.get_extensions(focus_alleles[2].id, "reference")
     assert result == [ann4, ann4]
@@ -402,13 +402,13 @@ def run_extensions_crud(
         focus_alleles[0].id, extension_name="classification"
     )
 
-    # fetch nonexistent annotation
+    # fetch nonexistent extension
     result = storage.get_extensions("ga4gh:VA.ZZZZZZZ")
     assert result == []
 
-    # delete annotations
+    # delete extensions
     result = storage.get_extensions(focus_alleles[0].id, "classification")
-    storage.delete_extension(result[0])
+    storage.delete_extensions(result[0].object_id, result[0].name, result[0].value)
     result = storage.get_extensions(focus_alleles[0].id, "classification")
     assert result == []
 


### PR DESCRIPTION
close #425 

replace existing storage class extension deletion method with one that takes an object ID and optionally an extension name(, and optionally a value), and performs a deletion specific to the parameters given. A rowcount is returned so that a client can figure out whether a delete did nothing because no extension matched those parameters or if it was because no object matching that ID exists.

Somewhat related, but writing it out: currently, extensions can be duplicative for object ID-name-value. This is because it's annoying to enforce uniqueness on anything that includes a JSON value.