### PR TITLE
feat: register protein sequence consequence/canonical allele catvars

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "python-multipart",  # required for fastapi file uploads
     "uvicorn",
     "ga4gh.vrs[extras]>=2.3.2,<3.0",
+    "ga4gh.cat_vrs>=0.7.1",
     "sqlalchemy~=2.0.0",
     "snowflake-sqlalchemy~=1.8.2",
     "pyyaml",

--- a/src/anyvar/anyvar.py
+++ b/src/anyvar/anyvar.py
@@ -1,7 +1,4 @@
-"""full-service interface to converting, validating, and registering
-biological sequence variation
-
-"""
+"""Full-service interface to converting, validating, and registering biological sequence variation."""
 
 import datetime
 import importlib.util
@@ -14,6 +11,11 @@ from urllib.parse import urlparse
 from ga4gh.vrs import models as vrs_models
 
 from anyvar.core import metadata, objects
+from anyvar.core.categorical_variants import (
+    CanonicalAllele,
+    ProteinSequenceConsequence,
+    is_expected_molecule_type,
+)
 from anyvar.core.objects import SupportedVrsObject
 from anyvar.storage import DEFAULT_STORAGE_URI
 from anyvar.storage.base import Storage
@@ -101,6 +103,10 @@ def has_queueing_enabled() -> bool:
 
 class ObjectNotFoundError(Exception):
     """Raised when an ID is given for a non-existent object."""
+
+
+class InvalidCategoricalVariantError(Exception):
+    """Raise when a provided categorical variant has invalid or missing required fields"""
 
 
 class AnyVar:
@@ -336,3 +342,51 @@ class AnyVar:
             except KeyError as e:
                 raise ObjectNotFoundError(object_id) from e
         return mappings
+
+    def register_ca_catvar(self, catvar: CanonicalAllele) -> None:
+        """Register a Canonical Allele Categorical Variant
+
+        Beyond the data structure validation performed by the catvar pydantic model,
+        this function also validates that the defining allele must be on a genomic sequence
+
+        Following successful validation, the catvar is stored for future reference.
+
+        :param catvar: user-supplied catvar
+        :raise InvalidCategoricalVariantError: if the molecule type for the defining allele can't be validated as genomic
+        """
+        if not is_expected_molecule_type(
+            catvar.constraints[0].root.allele.location.sequenceReference,
+            vrs_models.MoleculeType.GENOMIC,
+            self.translator.dp,
+        ):
+            msg = "Provided canonical allele constraint cannot be validated as referring to a genomic variation"
+            raise InvalidCategoricalVariantError(msg)
+        self.object_store.add_ca_catvar(catvar)
+
+    def get_ca_catvar(self, catvar_id: str) -> CanonicalAllele | None:
+        """Fetch a Canonical Allele catvar by ID"""
+        return self.object_store.get_ca_catvar(catvar_id)
+
+    def register_psq_catvar(self, catvar: ProteinSequenceConsequence) -> None:
+        """Register a Protein Sequence Consequence Categorical Variant
+
+        Beyond the data structure validation performed by the catvar pydantic model,
+        this function also validates that the defining allele must be on a protein sequence
+
+        Following successful validation, the catvar is stored for future reference.
+
+        :param catvar: user-supplied catvar
+        :raise InvalidCategoricalVariantError: if the molecule type for the defining allele can't be validated as protein
+        """
+        if not is_expected_molecule_type(
+            catvar.constraints[0].root.allele.location.sequenceReference,
+            vrs_models.MoleculeType.PROTEIN,
+            self.translator.dp,
+        ):
+            msg = "Provided canonical allele constraint cannot be validated as referring to a protein variation"
+            raise InvalidCategoricalVariantError(msg)
+        self.object_store.add_psq_catvar(catvar)
+
+    def get_psq_catvar(self, catvar_id: str) -> ProteinSequenceConsequence | None:
+        """Fetch a ProteinSequenceConsequence catvar by ID"""
+        return self.object_store.get_psq_catvar(catvar_id)

--- a/src/anyvar/core/categorical_variants.py
+++ b/src/anyvar/core/categorical_variants.py
@@ -1,0 +1,108 @@
+"""Provide core typing/structure for categorical variants."""
+
+import logging
+
+from ga4gh.cat_vrs import models as cat_vrs_models
+from ga4gh.vrs import models as vrs_models
+from ga4gh.vrs.dataproxy import _DataProxy
+from pydantic import Field, field_validator
+
+_logger = logging.getLogger(__name__)
+
+
+def is_expected_molecule_type(
+    seq_ref: vrs_models.SequenceReference,
+    expected_type: vrs_models.MoleculeType,
+    dp: _DataProxy,
+) -> bool:
+    """Validate that the given sequence reference has the expected molecule type
+
+    Currently only intended to support genomic and protein variants since that's what
+    we have catvars for
+
+    No further validation is performed if the `moleculeType` property is defined; its
+    value is accepted as authoritative and no additional sequence type lookup is
+    performed.
+
+    :param seq_ref: defining allele context's sequence reference object
+    :param expected_type: desired molecule type
+    :param dp: proxy for seq alias lookup
+    :return: whether the sequence reference's molecule type can be validated as consistent
+        with the expected molecule type
+    """
+    if seq_ref.moleculeType:
+        return seq_ref.moleculeType == expected_type
+
+    refseq_aliases = dp.translate_sequence_identifier(
+        f"ga4gh:{seq_ref.refgetAccession}", "refseq"
+    )
+    if not refseq_aliases:
+        _logger.debug(
+            "Unable to translate sequence accession %s to a known namespace",
+            seq_ref.refgetAccession,
+        )
+        return False
+    raw_seq_type = dp.extract_sequence_type(refseq_aliases[0])
+    if expected_type == vrs_models.MoleculeType.GENOMIC:
+        return raw_seq_type == "g"
+    if expected_type == vrs_models.MoleculeType.PROTEIN:
+        return raw_seq_type == "p"
+    _logger.debug(
+        "Encountered unexpected or unknown sequence type for %s: %s",
+        seq_ref.refgetAccession,
+        raw_seq_type,
+    )
+    return False
+
+
+class _SimpleAlleleCatVar(cat_vrs_models.CategoricalVariant):
+    """Abstract class for a simple Defining Allele Constraint-based catvar"""
+
+    id: str  # type: ignore[reportIncompatibleVariableOverride]
+    constraints: list[cat_vrs_models.Constraint] = Field(min_length=1, max_length=1)  # type: ignore[reportIncompatibleVariableOverride]
+
+    @field_validator("constraints")
+    @classmethod
+    def validate_constraints(
+        cls, constraints: list[cat_vrs_models.Constraint]
+    ) -> list[cat_vrs_models.Constraint]:
+        """Validate constraints property
+
+        :param constraints: Constraints property to validate
+        :return: Constraints property
+        :raises ValueError: If constraints property does not satisfy the requirements
+        """
+        constraint = constraints[0]  # guaranteed by pydantic to have exactly 1 element
+        if not isinstance(constraint.root, cat_vrs_models.DefiningAlleleConstraint):
+            raise ValueError("Constraint must be a DefiningAlleleConstraint")  # noqa: TRY004
+        return constraints
+
+
+class ProteinSequenceConsequence(_SimpleAlleleCatVar):
+    """ProteinSequenceConsequence catvar
+
+    Validates *shape* of input data, but does not validate *values*, ie that
+    given defining allele is of the expected molecule type, because that
+    requires external data access to SeqRepo (and that's messy to inject in a FastAPI endpoint).
+
+    The validations performed do differ from the original Cat-VRS recipes, which is why we
+    have a separate class.
+
+    It doesn't need any additional code implemented beyond its parent class,
+    but we still give it a separate class for mapping purposes in the ORM
+    """
+
+
+class CanonicalAllele(_SimpleAlleleCatVar):
+    """CanonicalAllele catvar
+
+    Validates *shape* of input data, but does not validate *values*, ie that
+    given defining allele is of the expected molecule type, because that
+    requires external data access to SeqRepo (and that's messy to inject in a FastAPI endpoint)
+
+    The validations performed do differ from the original Cat-VRS recipes, which is why we
+    have a separate class.
+
+    It doesn't need any additional code implemented beyond its parent class,
+    but we still give it a separate class for mapping purposes in the ORM
+    """

--- a/src/anyvar/restapi/categorical_variants_router.py
+++ b/src/anyvar/restapi/categorical_variants_router.py
@@ -1,0 +1,171 @@
+"""Provide API routes related to categorical variants"""
+
+from http import HTTPStatus
+from typing import Annotated
+
+from fastapi import APIRouter, Body, HTTPException, Request
+from ga4gh.cat_vrs import models as cat_vrs
+from ga4gh.vrs import models as vrs
+
+from anyvar.anyvar import AnyVar, InvalidCategoricalVariantError
+from anyvar.core.categorical_variants import CanonicalAllele, ProteinSequenceConsequence
+
+catvar_router = APIRouter()
+
+_put_psq_description = """Register a Protein Sequence Consequence Categorical Variant.
+
+AnyVar expects the following:
+
+* The provided object must be a valid Categorical Variant, per the Cat-VRS specification
+* It must contain a single constraint, which is a Defining Allele Constraint
+* The defining allele must be defined on a protein sequence
+* The Categorical Variant ID should be a reference to an external knowledgebase record
+
+AnyVar interprets this categorical variant as encompassing all variants that resolve to the provided defining allele through any combination of reference sequence liftover and transcript or protein projection.
+"""
+
+_put_psq_example = cat_vrs.CategoricalVariant(
+    id="civic.mpid:12",
+    name="BRAF V600E",
+    constraints=[
+        cat_vrs.Constraint(
+            root=cat_vrs.DefiningAlleleConstraint(
+                allele=vrs.Allele(
+                    id="ga4gh:VA.j4XnsLZcdzDIYa5pvvXM7t1wn9OITr0L",
+                    digest="j4XnsLZcdzDIYa5pvvXM7t1wn9OITr0L",
+                    location=vrs.SequenceLocation(
+                        id="ga4gh:SL.t-3DrWALhgLdXHsupI-e-M00aL3HgK3y",
+                        digest="t-3DrWALhgLdXHsupI-e-M00aL3HgK3y",
+                        sequenceReference=vrs.SequenceReference(
+                            refgetAccession="SQ.cQvw4UsHHRRlogxbWCB8W-mKD4AraM9y",
+                            moleculeType=vrs.MoleculeType.PROTEIN,
+                        ),
+                        start=599,
+                        end=600,
+                    ),
+                    state=vrs.LiteralSequenceExpression(
+                        sequence=vrs.sequenceString("E"),
+                    ),
+                )
+            )
+        )
+    ],
+)
+
+_put_psq_body = Body(
+    description="A protein sequence consequence categorical variant with an ID that references an external knowledgebase record.",
+    example=_put_psq_example,
+)
+
+
+@catvar_router.put(
+    "/protein_sequence_consequences",
+    response_model_exclude_none=True,
+    operation_id="put_psq",
+    summary="Register a protein sequence consequence categorical variant",
+    description=_put_psq_description,
+)
+def put_psq(
+    request: Request,
+    catvar: Annotated[ProteinSequenceConsequence, _put_psq_body],
+) -> None:
+    """Register a protein sequence consequence catvar"""
+    av: AnyVar = request.app.state.anyvar
+    try:
+        av.register_psq_catvar(catvar)
+    except InvalidCategoricalVariantError as e:
+        raise HTTPException(
+            status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+            detail="Validation checks failed -- see description for data requirements",
+        ) from e
+
+
+@catvar_router.get(
+    "/protein_sequence_consequences/{psq_id}", response_model_exclude_none=True
+)
+def get_protein_sequence_consequence(
+    request: Request, psq_id: str
+) -> ProteinSequenceConsequence:
+    """Fetch a Canonical Allele Categorical Variant by ID"""
+    av: AnyVar = request.app.state.anyvar
+    psq = av.get_psq_catvar(psq_id)
+    if not psq:
+        raise HTTPException(status_code=HTTPStatus.NOT_FOUND)
+    return psq
+
+
+_put_ca_example = cat_vrs.CategoricalVariant(
+    id="clingen.allele:CA413542193",
+    name="NM_005120.3(MED12):c.6352C>T (p.Gln2118Ter)",
+    constraints=[
+        cat_vrs.Constraint(
+            root=cat_vrs.DefiningAlleleConstraint(
+                allele=vrs.Allele(
+                    id="ga4gh:VA.m-WuNP-2lw3copqMFAEAiiViDp7Re1Rc",
+                    digest="m-WuNP-2lw3copqMFAEAiiViDp7Re1Rc",
+                    location=vrs.SequenceLocation(
+                        id="ga4gh:SL._9hCM5C6a-5s3MtaMeuJsu_uY17HIyf4",
+                        digest="_9hCM5C6a-5s3MtaMeuJsu_uY17HIyf4",
+                        end=71141314,
+                        start=71141313,
+                        sequenceReference=vrs.SequenceReference(
+                            refgetAccession="SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP",
+                            moleculeType=vrs.MoleculeType.GENOMIC,
+                        ),
+                    ),
+                    state=vrs.LiteralSequenceExpression(
+                        sequence=vrs.sequenceString("T")
+                    ),
+                )
+            )
+        )
+    ],
+)
+
+_put_ca_body = Body(
+    description="A canonical allele categorical variant with an ID that references an external knowledgebase record.",
+    example=_put_ca_example,
+)
+
+_put_ca_description = """Register a Canonical Allele Categorical Variant.
+
+AnyVar expects the following:
+
+* The provided object must be a valid Categorical Variant, per the Cat-VRS specification
+* It must contain a single constraint, which is a Defining Allele Constraint
+* The defining allele must be defined on a genomic sequence
+* The Categorical Variant ID should be a reference to an external knowledgebase record
+
+AnyVar interprets this categorical variant as encompassing all variants that the defining allele may resolve to via any combination of reference sequence liftover and transcription.
+"""
+
+
+@catvar_router.put(
+    "/canonical_alleles",
+    response_model_exclude_none=True,
+    operation_id="put_canonical_allele",
+    summary="Register a canonical allele categorical variant",
+    description=_put_ca_description,
+)
+def put_canonical_allele(
+    request: Request, catvar: Annotated[CanonicalAllele, _put_ca_body]
+) -> None:
+    """Register a canonical allele catvar"""
+    av: AnyVar = request.app.state.anyvar
+    try:
+        av.register_ca_catvar(catvar)
+    except InvalidCategoricalVariantError as e:
+        raise HTTPException(
+            status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+            detail="Validation checks failed -- see description for data requirements",
+        ) from e
+
+
+@catvar_router.get("/canonical_alleles/{ca_id}", response_model_exclude_none=True)
+def get_canonical_allele(request: Request, ca_id: str) -> CanonicalAllele:
+    """Fetch a Canonical Allele Categorical Variant by ID"""
+    av: AnyVar = request.app.state.anyvar
+    ca = av.get_ca_catvar(ca_id)
+    if not ca:
+        raise HTTPException(status_code=HTTPStatus.NOT_FOUND)
+    return ca

--- a/src/anyvar/restapi/main.py
+++ b/src/anyvar/restapi/main.py
@@ -17,6 +17,7 @@ from fastapi import (
 import anyvar
 from anyvar import AnyVar
 from anyvar.restapi.auth import get_token_auth_dependency
+from anyvar.restapi.categorical_variants_router import catvar_router
 from anyvar.restapi.meta_router import meta_router
 from anyvar.restapi.objects_router import objects_router
 from anyvar.restapi.schema import (
@@ -99,3 +100,8 @@ app.include_router(meta_router, tags=[EndpointTag.META])
 app.include_router(vcf_router, tags=[EndpointTag.VCF])
 app.include_router(variations_router, tags=[EndpointTag.VARIATIONS])
 app.include_router(objects_router, tags=[EndpointTag.VRS_OBJECTS])
+app.include_router(
+    catvar_router,
+    prefix="/categorical_variants",
+    tags=[EndpointTag.CATEGORICAL_VARIANTS],
+)

--- a/src/anyvar/restapi/schema.py
+++ b/src/anyvar/restapi/schema.py
@@ -7,6 +7,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
+from ga4gh.cat_vrs import CATVRS_VERSION
 from ga4gh.vrs import (
     VRS_VERSION,
     VrsType,
@@ -28,6 +29,7 @@ class EndpointTag(StrEnum):
     META = "Service Metadata"
     VCF = "VCF Operations"
     VRS_OBJECTS = "VRS Objects"
+    CATEGORICAL_VARIANTS = "Categorical Variants"
     VARIATIONS = "Variations"
 
 
@@ -71,6 +73,7 @@ class SpecMetadata(BaseModel):
     """Define substructure for reporting specification metadata."""
 
     vrs_version: str = VRS_VERSION
+    cat_vrs_version: str = CATVRS_VERSION
 
 
 class ImplMetadata(BaseModel):

--- a/src/anyvar/storage/base.py
+++ b/src/anyvar/storage/base.py
@@ -11,6 +11,7 @@ from pydantic import JsonValue
 
 from anyvar.core import metadata
 from anyvar.core import objects as anyvar_objects
+from anyvar.core.categorical_variants import CanonicalAllele, ProteinSequenceConsequence
 
 
 class StorageError(Exception):
@@ -257,4 +258,46 @@ class Storage(ABC):
         :param cursor: Opaque key indicating start location for query in pagination
         :return: Results page including variants and a cursor for next result page, if available
         :raise InvalidSearchParamsError: if above search param requirements are violated
+        """
+
+    @abstractmethod
+    def add_ca_catvar(self, ca: CanonicalAllele) -> None:
+        """Add a Canonical Allele Categorical Variant
+
+        This method **is not** responsible for validating that the provided catvar meets
+        data requirements to be considered a Canonical Allele instance;
+        passing an object without prior validation may raise unexpected errors
+
+        :param ca: canonical allele catvar
+        """
+
+    @abstractmethod
+    def get_ca_catvar(self, ca_id: str) -> CanonicalAllele | None:
+        """Fetch a Canonical Allele categorical variant by ID
+
+        Performs exact match -- case sensitive
+
+        :param ca_id: requested object ID
+        :return: matching canonical allele, if found
+        """
+
+    @abstractmethod
+    def add_psq_catvar(self, psq: ProteinSequenceConsequence) -> None:
+        """Add a Protein Sequence Consequence Categorical Variant
+
+        This method **is not** responsible for validating that the provided catvar meets
+        data requirements to be considered a Protein Sequence Consequence instance;
+        passing an object without prior validation may raise unexpected errors
+
+        :param psq: protein sequence consequence catvar
+        """
+
+    @abstractmethod
+    def get_psq_catvar(self, psq_id: str) -> ProteinSequenceConsequence | None:
+        """Fetch a Protein Sequence Consequence categorical variant by ID
+
+        Performs exact match -- case sensitive
+
+        :param psq_id: requested object ID
+        :return: matching canonical allele, if found
         """

--- a/src/anyvar/storage/duckdb.py
+++ b/src/anyvar/storage/duckdb.py
@@ -62,6 +62,10 @@ class DuckDbObjectStore(SqlAlchemyStorage):
         """Wipe all data from the storage backend."""
         # Need a bunch of redundant sessions for DuckDB reasons that I don't totally get
         with self.session_factory() as session, session.begin():
+            session.execute(delete(orm.ProteinSequenceConsequence))
+        with self.session_factory() as session, session.begin():
+            session.execute(delete(orm.CanonicalAllele))
+        with self.session_factory() as session, session.begin():
             session.execute(delete(orm.VariationMapping))
         with self.session_factory() as session, session.begin():
             session.execute(delete(orm.Allele))

--- a/src/anyvar/storage/mapper_registry.py
+++ b/src/anyvar/storage/mapper_registry.py
@@ -5,11 +5,14 @@ from typing import TypeVar
 from ga4gh.vrs import models as vrs_models
 
 from anyvar.core import metadata
+from anyvar.core.categorical_variants import CanonicalAllele, ProteinSequenceConsequence
 from anyvar.storage import orm
 from anyvar.storage.mappers import (
     AlleleMapper,
     BaseMapper,
+    CanonicalAlleleMapper,
     ExtensionMapper,
+    ProteinSequenceConsequenceMapper,
     SequenceLocationMapper,
     SequenceReferenceMapper,
     VariationMappingMapper,
@@ -29,6 +32,8 @@ class MapperRegistry:
             vrs_models.SequenceReference: orm.SequenceReference,
             metadata.VariationMapping: orm.VariationMapping,
             metadata.Extension: orm.Extension,
+            ProteinSequenceConsequence: orm.ProteinSequenceConsequence,
+            CanonicalAllele: orm.CanonicalAllele,
         }
 
         self._mappers: dict[type, BaseMapper] = {
@@ -37,6 +42,8 @@ class MapperRegistry:
             orm.SequenceReference: SequenceReferenceMapper(),
             orm.VariationMapping: VariationMappingMapper(),
             orm.Extension: ExtensionMapper(),
+            orm.ProteinSequenceConsequence: ProteinSequenceConsequenceMapper(),
+            orm.CanonicalAllele: CanonicalAlleleMapper(),
         }
 
     def get_mapper(self, entity_type: type[T]) -> BaseMapper:

--- a/src/anyvar/storage/mappers.py
+++ b/src/anyvar/storage/mappers.py
@@ -1,11 +1,14 @@
+# ruff: noqa: D101 D102 D107
 """Object mappers for converting between VRS models and database entities."""
 
 from abc import ABC, abstractmethod
 from typing import Generic, TypeVar
 
+from ga4gh.cat_vrs import models as cat_vrs_models
 from ga4gh.vrs import models as vrs_models
 
 from anyvar.core import metadata
+from anyvar.core.categorical_variants import CanonicalAllele, ProteinSequenceConsequence
 from anyvar.storage import orm
 
 A = TypeVar("A")  # Anyvar entity type
@@ -245,3 +248,65 @@ class ExtensionMapper(BaseMapper[metadata.Extension, orm.Extension]):
         :return: An ORM model Extension instance
         """
         return orm.Extension(**anyvar_entity.model_dump())
+
+
+class ProteinSequenceConsequenceMapper(
+    BaseMapper[ProteinSequenceConsequence, orm.ProteinSequenceConsequence]
+):
+    def __init__(self) -> None:
+        self.allele_mapper = AlleleMapper()
+
+    def from_db_entity(
+        self, db_entity: orm.ProteinSequenceConsequence
+    ) -> ProteinSequenceConsequence:
+        return ProteinSequenceConsequence(
+            id=db_entity.id,
+            name=db_entity.name,
+            constraints=[
+                cat_vrs_models.Constraint(
+                    root=cat_vrs_models.DefiningAlleleConstraint(
+                        allele=self.allele_mapper.from_db_entity(db_entity.allele)
+                    )
+                )
+            ],
+        )
+
+    def to_db_entity(
+        self, anyvar_entity: ProteinSequenceConsequence
+    ) -> orm.ProteinSequenceConsequence:
+        return orm.ProteinSequenceConsequence(
+            id=anyvar_entity.id,
+            name=anyvar_entity.name,
+            allele_id=anyvar_entity.constraints[0].root.allele.id,
+            allele=self.allele_mapper.to_db_entity(
+                anyvar_entity.constraints[0].root.allele
+            ),
+        )
+
+
+class CanonicalAlleleMapper(BaseMapper[CanonicalAllele, orm.CanonicalAllele]):
+    def __init__(self) -> None:
+        self.allele_mapper = AlleleMapper()
+
+    def from_db_entity(self, db_entity: orm.CanonicalAllele) -> CanonicalAllele:
+        return CanonicalAllele(
+            id=db_entity.id,
+            name=db_entity.name,
+            constraints=[
+                cat_vrs_models.Constraint(
+                    root=cat_vrs_models.DefiningAlleleConstraint(
+                        allele=self.allele_mapper.from_db_entity(db_entity.allele)
+                    )
+                )
+            ],
+        )
+
+    def to_db_entity(self, anyvar_entity: CanonicalAllele) -> orm.CanonicalAllele:
+        return orm.CanonicalAllele(
+            id=anyvar_entity.id,
+            name=anyvar_entity.name,
+            allele_id=anyvar_entity.constraints[0].root.allele.id,
+            allele=self.allele_mapper.to_db_entity(
+                anyvar_entity.constraints[0].root.allele
+            ),
+        )

--- a/src/anyvar/storage/no_db.py
+++ b/src/anyvar/storage/no_db.py
@@ -10,6 +10,7 @@ from pydantic import JsonValue
 
 from anyvar.core import metadata
 from anyvar.core import objects as anyvar_objects
+from anyvar.core.categorical_variants import CanonicalAllele, ProteinSequenceConsequence
 from anyvar.storage.base import AlleleSearchPage, Storage
 
 
@@ -89,3 +90,15 @@ class NoObjectStore(Storage):
     ) -> AlleleSearchPage:
         """(No-op) Find all Alleles within the specified interval."""
         return AlleleSearchPage(items=[], next_cursor=None)
+
+    def add_ca_catvar(self, ca: CanonicalAllele) -> None:
+        """(No-op) Add a Canonical Allele Categorical Variant"""
+
+    def get_ca_catvar(self, ca_id: str) -> CanonicalAllele | None:
+        """(No-op) Fetch a Canonical Allele categorical variant by ID"""
+
+    def add_psq_catvar(self, psq: ProteinSequenceConsequence) -> None:
+        """(No-op) Add a Protein Sequence Consequence Categorical Variant"""
+
+    def get_psq_catvar(self, psq_id: str) -> ProteinSequenceConsequence | None:
+        """(No-op) Fetch a Protein Sequence Consequence categorical variant by ID"""

--- a/src/anyvar/storage/orm.py
+++ b/src/anyvar/storage/orm.py
@@ -238,6 +238,33 @@ class VariationMapping(Base):
         return ()
 
 
+class CanonicalAllele(Base):
+    """AnyVar ORM model for canonical allele variants"""
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    name: Mapped[str]
+    allele_id: Mapped[str] = mapped_column(String, ForeignKey(Allele.id))
+    allele: Mapped[Allele] = relationship()
+
+
+class ProteinSequenceConsequence(Base):
+    """AnyVar ORM model for canonical allele variants"""
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    name: Mapped[str]
+    allele_id: Mapped[str] = mapped_column(String, ForeignKey(Allele.id))
+    allele: Mapped[Allele] = relationship()
+
+
+def create_tables(db_url: str) -> None:
+    """Create all tables in the database.
+
+    :param db_url: Database connection URL (e.g., postgresql://user:pass@host:port/db)
+    """
+    engine = create_engine(db_url)
+    Base.metadata.create_all(engine)
+
+
 def session_factory(db_url: str) -> sessionmaker:
     """Create a SQLAlchemy session factory.
 

--- a/src/anyvar/storage/postgres.py
+++ b/src/anyvar/storage/postgres.py
@@ -3,14 +3,7 @@
 import json
 
 from pydantic import JsonValue
-from sqlalchemy import (
-    ColumnElement,
-    Engine,
-    Index,
-    create_engine,
-    delete,
-    func,
-)
+from sqlalchemy import ColumnElement, Engine, Index, create_engine, delete, func
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session, sessionmaker
 

--- a/src/anyvar/storage/snowflake.py
+++ b/src/anyvar/storage/snowflake.py
@@ -37,6 +37,7 @@ from sqlalchemy.sql.expression import Insert
 
 from anyvar.core import metadata
 from anyvar.core import objects as anyvar_objects
+from anyvar.core.categorical_variants import CanonicalAllele, ProteinSequenceConsequence
 from anyvar.storage import orm
 from anyvar.storage.base import (
     AlleleSearchPage,
@@ -742,6 +743,48 @@ class SnowflakeObjectStore(Storage):
             last = page_db[-1]
             next_cursor = self._encode_search_cursor(last.location.start, last.id)
             return AlleleSearchPage(items=items, next_cursor=next_cursor)
+
+    def add_ca_catvar(self, ca: CanonicalAllele) -> None:
+        """Add a Canonical Allele Categorical Variant
+
+        This method **is not** responsible for validating that the provided catvar meets
+        data requirements to be considered a Canonical Allele instance;
+        passing an object without prior validation may raise unexpected errors
+
+        :param ca: canonical allele catvar
+        """
+        raise NotImplementedError("This feature is not yet supported for Snowflake")
+
+    def get_ca_catvar(self, ca_id: str) -> CanonicalAllele | None:
+        """Fetch a Canonical Allele categorical variant by ID
+
+        Performs exact match -- case sensitive
+
+        :param ca_id: requested object ID
+        :return: matching canonical allele, if found
+        """
+        raise NotImplementedError("This feature is not yet supported for Snowflake")
+
+    def add_psq_catvar(self, psq: ProteinSequenceConsequence) -> None:
+        """Add a Protein Sequence Consequence Categorical Variant
+
+        This method **is not** responsible for validating that the provided catvar meets
+        data requirements to be considered a Protein Sequence Consequence instance;
+        passing an object without prior validation may raise unexpected errors
+
+        :param psq: protein sequence consequence catvar
+        """
+        raise NotImplementedError("This feature is not yet supported for Snowflake")
+
+    def get_psq_catvar(self, psq_id: str) -> ProteinSequenceConsequence | None:
+        """Fetch a Protein Sequence Consequence categorical variant by ID
+
+        Performs exact match -- case sensitive
+
+        :param psq_id: requested object ID
+        :return: matching canonical allele, if found
+        """
+        raise NotImplementedError("This feature is not yet supported for Snowflake")
 
 
 @compiles(Insert, "snowflake")

--- a/src/anyvar/storage/sqlalchemy.py
+++ b/src/anyvar/storage/sqlalchemy.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import Session, joinedload, sessionmaker
 
 from anyvar.core import metadata
 from anyvar.core import objects as anyvar_objects
+from anyvar.core.categorical_variants import CanonicalAllele, ProteinSequenceConsequence
 from anyvar.storage import orm
 from anyvar.storage.base import (
     AlleleSearchPage,
@@ -47,6 +48,8 @@ class SqlAlchemyStorage(Storage):
     def wipe_db(self) -> None:
         """Wipe all data from the storage backend."""
         with self.session_factory() as session, session.begin():
+            session.execute(delete(orm.CanonicalAllele))
+            session.execute(delete(orm.ProteinSequenceConsequence))
             session.execute(delete(orm.VariationMapping))
             session.execute(delete(orm.Allele))
             session.execute(delete(orm.Location))
@@ -447,3 +450,60 @@ class SqlAlchemyStorage(Storage):
             last = page_db[-1]
             next_cursor = self._encode_search_cursor(last.location.start, last.id)
             return AlleleSearchPage(items=items, next_cursor=next_cursor)
+
+    def add_ca_catvar(self, ca: CanonicalAllele) -> None:
+        """Add a Canonical Allele Categorical Variant
+
+        This method **is not** responsible for validating that the provided catvar meets
+        data requirements to be considered a Canonical Allele instance;
+        passing an object without prior validation may raise unexpected errors
+
+        :param ca: canonical allele catvar
+        """
+        db_entity: orm.CanonicalAllele = mapper_registry.to_db_entity(ca)
+        with self.session_factory() as session, session.begin():
+            session.merge(db_entity.allele)
+            session.merge(db_entity)
+
+    def get_ca_catvar(self, ca_id: str) -> CanonicalAllele | None:
+        """Fetch a Canonical Allele categorical variant by ID
+
+        Performs exact match -- case sensitive
+
+        :param ca_id: requested object ID
+        :return: matching canonical allele, if found
+        """
+        with self.session_factory() as session, session.begin():
+            ca = session.get(orm.CanonicalAllele, ca_id)
+            if ca:
+                return mapper_registry.from_db_entity(ca)
+        return None
+
+    def add_psq_catvar(self, psq: ProteinSequenceConsequence) -> None:
+        """Add a Protein Sequence Consequence Categorical Variant
+
+        This method **is not** responsible for validating that the provided catvar meets
+        data requirements to be considered a Protein Sequence Consequence instance;
+        passing an object without prior validation may raise unexpected errors
+
+        :param psq: protein sequence consequence catvar
+        """
+        db_entity: orm.ProteinSequenceConsequence = mapper_registry.to_db_entity(psq)
+        with self.session_factory() as session, session.begin():
+            session.merge(db_entity.allele)
+            session.flush()
+            session.merge(db_entity)
+
+    def get_psq_catvar(self, psq_id: str) -> ProteinSequenceConsequence | None:
+        """Fetch a Protein Sequence Consequence categorical variant by ID
+
+        Performs exact match -- case sensitive
+
+        :param psq_id: requested object ID
+        :return: matching canonical allele, if found
+        """
+        with self.session_factory() as session, session.begin():
+            ca = session.get(orm.ProteinSequenceConsequence, psq_id)
+            if ca:
+                return mapper_registry.from_db_entity(ca)
+        return None

--- a/tests/data/variations.json
+++ b/tests/data/variations.json
@@ -66,7 +66,10 @@
           "start": 140753335,
           "end": 140753336
         },
-        "state": { "type": "LiteralSequenceExpression", "sequence": "T" }
+        "state": {
+          "type": "LiteralSequenceExpression",
+          "sequence": "T"
+        }
       },
       "comment": "BRAF V600E (genomic), grch38. liftover to VA.nmp-bzYpO00NYIqr3CaVF0ZH2ZpSj1ly"
     },
@@ -109,7 +112,10 @@
           "start": 140453135,
           "end": 140453136
         },
-        "state": { "type": "LiteralSequenceExpression", "sequence": "T" }
+        "state": {
+          "type": "LiteralSequenceExpression",
+          "sequence": "T"
+        }
       },
       "comment": "BRAF V600E (genomic), grch37. liftover to VA.Otc5ovrw906Ack087o1fhegB4jDRqCAe"
     },
@@ -129,7 +135,10 @@
           "start": 55174014,
           "end": 55174015
         },
-        "state": { "type": "LiteralSequenceExpression", "sequence": "C" }
+        "state": {
+          "type": "LiteralSequenceExpression",
+          "sequence": "C"
+        }
       },
       "comment": "NM_005228.5(EGFR):c.2156G>C (p.Gly719Ala) -- VCV000045225.8"
     },
@@ -149,7 +158,10 @@
           "start": 178921548,
           "end": 178921549
         },
-        "state": { "type": "LiteralSequenceExpression", "sequence": "G" }
+        "state": {
+          "type": "LiteralSequenceExpression",
+          "sequence": "G"
+        }
       },
       "comment": "grch37, lifts over to 9gW_iJbQAIO3SIxJ9ACyAZA1X2lEgO39"
     },
@@ -169,7 +181,10 @@
           "end": 179203761,
           "type": "SequenceLocation"
         },
-        "state": { "sequence": "G", "type": "LiteralSequenceExpression" }
+        "state": {
+          "sequence": "G",
+          "type": "LiteralSequenceExpression"
+        }
       },
       "comment": "allele_int_unknown_grch38_variant, lifts over to VA.J-gW7La8EblIdT1MfqZzhzbO26lkEH7D"
     },
@@ -227,7 +242,9 @@
       "register_params": {
         "definition": "NM_000551.3:c.1A>T"
       },
-      "expected_messages": ["Unable to complete liftover: Could not resolve reference assembly - accession not found in any supported assembly"],
+      "expected_messages": [
+        "Unable to complete liftover: Could not resolve reference assembly - accession not found in any supported assembly"
+      ],
       "variation": {
         "digest": "1FzYrqG-7jB3Wr46eIL_L5BWElQZEB7i",
         "id": "ga4gh:VA.1FzYrqG-7jB3Wr46eIL_L5BWElQZEB7i",
@@ -265,7 +282,10 @@
             "type": "SequenceReference"
           }
         },
-        "state": { "sequence": "T", "type": "LiteralSequenceExpression" }
+        "state": {
+          "sequence": "T",
+          "type": "LiteralSequenceExpression"
+        }
       },
       "comment": "grch36"
     },
@@ -285,7 +305,10 @@
           "start": 47087473,
           "end": 47087474
         },
-        "state": { "type": "LiteralSequenceExpression", "sequence": "T" }
+        "state": {
+          "type": "LiteralSequenceExpression",
+          "sequence": "T"
+        }
       },
       "comment": "grch37 -- cant liftover to grch38"
     },
@@ -417,6 +440,52 @@
         }
       },
       "comment": "gnomad grch38"
+    },
+    "ga4gh:VA.sMA9h8fzDi0RvweMlxtD0_Oi8B-JZ1V-": {
+      "variation": {
+        "id": "ga4gh:VA.sMA9h8fzDi0RvweMlxtD0_Oi8B-JZ1V-",
+        "type": "Allele",
+        "digest": "sMA9h8fzDi0RvweMlxtD0_Oi8B-JZ1V-",
+        "location": {
+          "id": "ga4gh:SL.UOSDv-_5QNbKqgbCf--isFjvNZ5ZST09",
+          "type": "SequenceLocation",
+          "digest": "UOSDv-_5QNbKqgbCf--isFjvNZ5ZST09",
+          "sequenceReference": {
+            "type": "SequenceReference",
+            "refgetAccession": "SQ.vyo55F6mA6n2LgN4cagcdRzOuh38V4mE"
+          },
+          "start": 789,
+          "end": 790
+        },
+        "state": {
+          "type": "LiteralSequenceExpression",
+          "sequence": "M"
+        }
+      },
+      "comment": "EGFR T790M (civic.mpid:34)"
+    },
+    "ga4gh:VA.EEk-kGY1YF1QgGShZ040hl3V5HWXsL4q": {
+      "variation": {
+        "id": "ga4gh:VA.EEk-kGY1YF1QgGShZ040hl3V5HWXsL4q",
+        "type": "Allele",
+        "digest": "EEk-kGY1YF1QgGShZ040hl3V5HWXsL4q",
+        "location": {
+          "id": "ga4gh:SL.BP0NxO71lCOCWwwzfD_Ic19LIoGVG5J7",
+          "type": "SequenceLocation",
+          "digest": "BP0NxO71lCOCWwwzfD_Ic19LIoGVG5J7",
+          "sequenceReference": {
+            "type": "SequenceReference",
+            "refgetAccession": "SQ.2NkFm8HK88MqeNkCgj78KidCAXgnsfV1"
+          },
+          "start": 68032290,
+          "end": 68032291
+        },
+        "state": {
+          "type": "LiteralSequenceExpression",
+          "sequence": "T"
+        }
+      },
+      "comment": "NC_000011.10:g.68032291C>T (clingen.allele:CA321211)"
     }
   },
   "copy_numbers": {

--- a/tests/integration/restapi/test_catvars_router.py
+++ b/tests/integration/restapi/test_catvars_router.py
@@ -1,0 +1,163 @@
+from http import HTTPStatus
+
+from fastapi.testclient import TestClient
+from ga4gh.cat_vrs.models import (
+    CategoricalVariant,
+    Constraint,
+    DefiningAlleleConstraint,
+)
+
+from anyvar.restapi.categorical_variants_router import _put_ca_example, _put_psq_example
+
+
+def test_register_psq(restapi_client: TestClient, alleles: dict):
+    payload = CategoricalVariant(
+        id="civic.mpid:34",
+        name="EGFR T790M",
+        constraints=[
+            Constraint(
+                root=DefiningAlleleConstraint(
+                    allele=alleles["ga4gh:VA.sMA9h8fzDi0RvweMlxtD0_Oi8B-JZ1V-"][
+                        "variation"
+                    ]
+                )
+            )
+        ],
+    )
+    put_response = restapi_client.put(
+        "/categorical_variants/protein_sequence_consequences",
+        json=payload.model_dump(),
+    )
+    assert put_response.status_code == HTTPStatus.OK
+
+    get_response = restapi_client.get(
+        f"/categorical_variants/protein_sequence_consequences/{payload.id}"
+    )
+    assert get_response.status_code == HTTPStatus.OK
+    assert CategoricalVariant(**get_response.json()) == payload
+
+
+def test_get_unregistered_psq(restapi_client: TestClient):
+    response = restapi_client.get(
+        "/categorical_variants/protein_sequence_consequences/fake:12345"
+    )
+    assert response.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_register_psq_example(restapi_client: TestClient):
+    put_response = restapi_client.put(
+        "/categorical_variants/protein_sequence_consequences",
+        json=_put_psq_example.model_dump(),
+    )
+    assert put_response.status_code == HTTPStatus.OK
+
+    get_response = restapi_client.get(
+        f"/categorical_variants/protein_sequence_consequences/{_put_psq_example.id}"
+    )
+    assert get_response.status_code == HTTPStatus.OK
+    assert CategoricalVariant(**get_response.json()) == _put_psq_example
+
+
+def test_register_psq_nonprotein(restapi_client: TestClient):
+    response = restapi_client.put(
+        "/categorical_variants/protein_sequence_consequences",
+        json=_put_ca_example.model_dump(),
+    )
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+def test_register_psq_invalid(restapi_client: TestClient, alleles: dict):
+    payload = CategoricalVariant(
+        name="EGFR T790M",
+        constraints=[
+            Constraint(
+                root=DefiningAlleleConstraint(
+                    allele=alleles["ga4gh:VA.sMA9h8fzDi0RvweMlxtD0_Oi8B-JZ1V-"][
+                        "variation"
+                    ]
+                )
+            )
+        ],
+    )
+    response = restapi_client.put(
+        "/categorical_variants/protein_sequence_consequences",
+        json=payload.model_dump(),
+    )
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+def test_register_ca(restapi_client: TestClient, alleles: dict):
+    payload = CategoricalVariant(
+        id="clingen.allele:CA321211",
+        name="NC_000007.13:g.36561662_36561663del",
+        constraints=[
+            Constraint(
+                root=DefiningAlleleConstraint(
+                    allele=alleles["ga4gh:VA.EEk-kGY1YF1QgGShZ040hl3V5HWXsL4q"][
+                        "variation"
+                    ]
+                )
+            ),
+        ],
+    )
+    put_response = restapi_client.put(
+        "/categorical_variants/canonical_alleles",
+        json=payload.model_dump(),
+    )
+    assert put_response.status_code == HTTPStatus.OK
+
+    get_response = restapi_client.get(
+        f"/categorical_variants/canonical_alleles/{payload.id}"
+    )
+    assert get_response.status_code == HTTPStatus.OK
+    assert CategoricalVariant(**get_response.json()) == payload
+
+
+def test_register_ca_example(restapi_client: TestClient):
+    put_response = restapi_client.put(
+        "/categorical_variants/canonical_alleles",
+        json=_put_ca_example.model_dump(),
+    )
+    assert put_response.status_code == HTTPStatus.OK
+
+    get_response = restapi_client.get(
+        f"/categorical_variants/canonical_alleles/{_put_ca_example.id}"
+    )
+    assert get_response.status_code == HTTPStatus.OK
+    assert CategoricalVariant(**get_response.json()) == _put_ca_example
+
+
+def test_register_ca_nongenomic(restapi_client: TestClient):
+    response = restapi_client.put(
+        "/categorical_variants/canonical_alleles",
+        json=_put_psq_example.model_dump(),
+    )
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+def test_register_ca_invalid(restapi_client: TestClient, alleles: dict):
+    payload = CategoricalVariant(
+        id="clingen.allele:CA321211",
+        name="NC_000007.13:g.36561662_36561663del",
+        constraints=[
+            Constraint(
+                root=DefiningAlleleConstraint(
+                    allele=alleles["ga4gh:VA.EEk-kGY1YF1QgGShZ040hl3V5HWXsL4q"][
+                        "variation"
+                    ]
+                )
+            ),
+            Constraint(
+                root=DefiningAlleleConstraint(
+                    allele=alleles["ga4gh:VA.EEk-kGY1YF1QgGShZ040hl3V5HWXsL4q"][
+                        "variation"
+                    ]
+                )
+            ),
+        ],
+    )
+    response = restapi_client.put(
+        "/categorical_variants/canonical_alleles",
+        json=payload.model_dump(),
+    )
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY

--- a/tests/unit/storage/storage_test_funcs.py
+++ b/tests/unit/storage/storage_test_funcs.py
@@ -1,9 +1,11 @@
 """Functions to run common storage tests on different storage backends."""
 
 import pytest
+from ga4gh.cat_vrs.models import Constraint, DefiningAlleleConstraint
 from ga4gh.vrs import models
 
 from anyvar.core import metadata
+from anyvar.core.categorical_variants import CanonicalAllele, ProteinSequenceConsequence
 from anyvar.storage.base import (
     DataIntegrityError,
     IncompleteVrsObjectError,
@@ -516,3 +518,63 @@ def run_search_alleles(
     )
     assert result.items == []
     assert result.next_cursor is None
+
+
+def run_psqs_crud(
+    storage: Storage,
+    validated_vrs_alleles: dict[str, models.Allele],
+):
+    civic_mpid = "civic.mpid:34"
+    allele = validated_vrs_alleles["ga4gh:VA.sMA9h8fzDi0RvweMlxtD0_Oi8B-JZ1V-"]
+    psq_input = ProteinSequenceConsequence(
+        id=civic_mpid,
+        name="EGFR T790M",
+        constraints=[Constraint(root=DefiningAlleleConstraint(allele=allele))],
+    )
+    storage.add_psq_catvar(psq_input)
+
+    result = storage.get_psq_catvar(civic_mpid)
+    assert result == psq_input
+
+    # test idempotency
+    storage.add_psq_catvar(psq_input)
+
+    result = storage.get_psq_catvar(civic_mpid)
+    assert result == psq_input
+
+    # test adding catvar for existing allele
+    storage.wipe_db()
+    storage.add_objects([allele])
+    storage.add_psq_catvar(psq_input)
+    result = storage.get_psq_catvar(civic_mpid)
+    assert result == psq_input
+
+
+def run_canonical_alleles_crud(
+    storage: Storage,
+    validated_vrs_alleles: dict[str, models.Allele],
+):
+    clingen_id = "clingen.allele:CA321211"
+    allele = validated_vrs_alleles["ga4gh:VA.EEk-kGY1YF1QgGShZ040hl3V5HWXsL4q"]
+    ca_input = CanonicalAllele(
+        id=clingen_id,
+        name="NC_000007.13:g.36561662_36561663del",
+        constraints=[Constraint(root=DefiningAlleleConstraint(allele=allele))],
+    )
+    storage.add_ca_catvar(ca_input)
+
+    result = storage.get_ca_catvar(clingen_id)
+    assert result == ca_input
+
+    # test idempotency
+    storage.add_ca_catvar(ca_input)
+
+    result = storage.get_ca_catvar(clingen_id)
+    assert result == ca_input
+
+    # test adding catvar for existing allele
+    storage.wipe_db()
+    storage.add_objects([allele])
+    storage.add_ca_catvar(ca_input)
+    result = storage.get_ca_catvar(clingen_id)
+    assert result == ca_input

--- a/tests/unit/storage/test_duckdb.py
+++ b/tests/unit/storage/test_duckdb.py
@@ -10,6 +10,7 @@ from .storage_test_funcs import (
     run_incomplete_objects_error,
     run_mappings_crud,
     run_objects_raises_integrityerror,
+    run_psqs_crud,
     run_search_alleles,
     run_sequencelocations_crud,
     run_sequencereferences_crud,
@@ -99,3 +100,10 @@ def test_search_alleles(
     validated_vrs_alleles: dict[str, models.Allele],
 ):
     run_search_alleles(duckdb_storage, validated_vrs_alleles)
+
+
+@pytest.mark.ci_ok
+def test_psqs_crud(
+    duckdb_storage: DuckDbObjectStore, validated_vrs_alleles: dict[str, models.Allele]
+):
+    run_psqs_crud(duckdb_storage, validated_vrs_alleles)

--- a/tests/unit/storage/test_postgres.py
+++ b/tests/unit/storage/test_postgres.py
@@ -9,11 +9,13 @@ from anyvar.storage.postgres import PostgresObjectStore
 
 from .storage_test_funcs import (
     run_alleles_crud,
+    run_canonical_alleles_crud,
     run_db_lifecycle,
     run_extensions_crud,
     run_incomplete_objects_error,
     run_mappings_crud,
     run_objects_raises_integrityerror,
+    run_psqs_crud,
     run_search_alleles,
     run_sequencelocations_crud,
     run_sequencereferences_crud,
@@ -109,3 +111,19 @@ def test_search_alleles(
     validated_vrs_alleles: dict[str, models.Allele],
 ):
     run_search_alleles(postgres_storage, validated_vrs_alleles)
+
+
+@pytest.mark.ci_ok
+def test_psqs_crud(
+    postgres_storage: PostgresObjectStore,
+    validated_vrs_alleles: dict[str, models.Allele],
+):
+    run_psqs_crud(postgres_storage, validated_vrs_alleles)
+
+
+@pytest.mark.ci_ok
+def test_canonicalalleles_crud(
+    postgres_storage: PostgresObjectStore,
+    validated_vrs_alleles: dict[str, models.Allele],
+):
+    run_canonical_alleles_crud(postgres_storage, validated_vrs_alleles)

--- a/tests/unit/test_catvars.py
+++ b/tests/unit/test_catvars.py
@@ -1,0 +1,40 @@
+from ga4gh.vrs.models import MoleculeType, SequenceReference
+
+from anyvar.core.categorical_variants import is_expected_molecule_type
+from anyvar.translate.vrs_python import VrsPythonTranslator
+
+
+def test_is_expected_molecule_type(alleles: dict, translator: VrsPythonTranslator):
+    seq_ref = SequenceReference(
+        **alleles["ga4gh:VA.d6ru7RcuVO0-v3TtPFX5fZz-GLQDhMVb"]["variation"]["location"][
+            "sequenceReference"
+        ]
+    )
+    assert not is_expected_molecule_type(seq_ref, MoleculeType.PROTEIN, translator.dp)
+    assert is_expected_molecule_type(seq_ref, MoleculeType.GENOMIC, translator.dp)
+
+    # check that moleculeType is given priority
+    seq_ref.moleculeType = MoleculeType.GENOMIC
+    assert not is_expected_molecule_type(seq_ref, MoleculeType.PROTEIN, translator.dp)
+    assert is_expected_molecule_type(seq_ref, MoleculeType.GENOMIC, translator.dp)
+
+    # even if it's wrong
+    seq_ref.moleculeType = MoleculeType.PROTEIN
+    assert is_expected_molecule_type(seq_ref, MoleculeType.PROTEIN, translator.dp)
+    assert not is_expected_molecule_type(seq_ref, MoleculeType.GENOMIC, translator.dp)
+
+    seq_ref = SequenceReference(
+        **alleles["ga4gh:VA.VrGVDMrq3BCWHIopVxMDtVpMOrxjfQJC"]["variation"]["location"][
+            "sequenceReference"
+        ]
+    )
+    assert not is_expected_molecule_type(seq_ref, MoleculeType.GENOMIC, translator.dp)
+    assert is_expected_molecule_type(seq_ref, MoleculeType.PROTEIN, translator.dp)
+
+    seq_ref = SequenceReference(
+        **alleles["ga4gh:VA.pc65jiqYvcLLocEPb3msu216eBQ3R-mr"]["variation"]["location"][
+            "sequenceReference"
+        ]
+    )
+    assert not is_expected_molecule_type(seq_ref, MoleculeType.GENOMIC, translator.dp)
+    assert not is_expected_molecule_type(seq_ref, MoleculeType.PROTEIN, translator.dp)


### PR DESCRIPTION
close #453

## Decisions

* `/categorical_variants` not `/categorical_variations`. I don't even know which is correct at this point
* the "reference" to the external resource is just the ID of the catvar itself. So rather than making a catvar with an "xref" to a clingen allele record, the `id` field is just `clingen.allele:CA12345`. And similarly, fetching that specific catvar is `GET /categorical_variants/canonical_alleles/clingen.allele:CA12345`
* Rather than a general "drop in a catvar, have some indication of its type, let anyvar figure it out" endpoint, I just made resource type-specific registration endpoints, I think that's better for our sanity and avoids inventing any new conventions. Similarly, there are separate sql tables for each categorical variant type. I had wanted to be slick but it probably makes more sense to just use a new table for each type.
* Make new classes for PSQ's/CA's instead of reusing `ga4gh.cat_vrs` recipes, a couple reasons
    1) we want to be stricter about some validation things (ID is required, `len(constraints) == 1`)
    2) we might want to interpret relations differently than the recipes do, now or in the future
* Validating molecule type is done outside of the pydantic `field_validator` because it might require seqrepo access. Alternatives here could be 1) requiring the submitter to explicitly declare molecule type and trusting it, or 2) injecting validation context into the fastapi route validation logic, but that looked like it was going to be insane.  It's also possible that this function will duplicate work from the projection end point so whichever one gets merged second can resolve that.
* Request paths below -- also add basic GET by ID for round-trip testing and also because it just seems reasonable and enabled roundtrip testing
* Haven't added any `relations` to the input or output objects yet, pending final determination on how we implement our search functions. But broadly, I think you could just make sure to add in the right values when the object is coming back out to the user. Not sure if it's worth validating them on the way in. 
* Haven't updated docs yet, pending final search endpoint behavior
* Didn't add a Snowflake implementation because a) scary and b) maybe we are ending snowflake support?

## Routes

`PUT /categorical_variants/canonical_alleles` -- to register a CA
`GET /categorical_variants/canonical_alleles/<id>` -- to fetch a CA by ID
`PUT /categorical_variants/protein_sequence_consequences` -- to register a PSQ
`GET /categorical_variants/protein_sequence_consequences/<id>` -- to fetch a PSQ by ID