### PR TITLE
Allow variation registration in stateless mode

### DIFF
--- a/src/anyvar/anyvar.py
+++ b/src/anyvar/anyvar.py
@@ -17,6 +17,7 @@ from anyvar.core import metadata, objects
 from anyvar.core.objects import SupportedVrsObject
 from anyvar.storage import DEFAULT_STORAGE_URI
 from anyvar.storage.base import Storage
+from anyvar.storage.no_db import NoObjectStore
 from anyvar.translate.base import Translator
 from anyvar.translate.vrs_python import VrsPythonTranslator
 
@@ -235,7 +236,7 @@ class AnyVar:
         except Exception as e:
             _logger.exception("Failed to retrieve extensions for object: %s", object_id)
             raise e  # noqa: TRY201
-        if not extensions:
+        if not extensions and not isinstance(self.object_store, NoObjectStore):
             try:
                 _ = self.get_object(object_id)
             except KeyError as e:


### PR DESCRIPTION
Variation registration calls `create_timestamp_if_missing()` to populate the timestamp extension for the registered variation.  This in turn calls `get_object_extensions()` to determine if the extension already exists.  `get_object_extensions()` throws an error if the variation is not found.  In stateless mode, the `NoObjectStore` always throws an error on `get_object()`.

Changed code to not check for variation existence in store when in stateless mode.