### PR TITLE
feat!: add DuckDB storage backend

### DIFF
--- a/docs/source/api/api/storage/anyvar.storage.duckdb.rst
+++ b/docs/source/api/api/storage/anyvar.storage.duckdb.rst
@@ -1,0 +1,9 @@
+﻿anyvar.storage.duckdb
+=====================
+
+.. automodule:: anyvar.storage.duckdb
+   :members:
+   :no-inherited-members:
+   :undoc-members:
+   :special-members: __init__
+   :exclude-members: model_fields, model_config, metadata

--- a/docs/source/api/api/storage/anyvar.storage.snowflake.rst
+++ b/docs/source/api/api/storage/anyvar.storage.snowflake.rst
@@ -1,0 +1,9 @@
+﻿anyvar.storage.snowflake
+========================
+
+.. automodule:: anyvar.storage.snowflake
+   :members:
+   :no-inherited-members:
+   :undoc-members:
+   :special-members: __init__
+   :exclude-members: model_fields, model_config, metadata

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -46,6 +46,8 @@ Object Storage
 
    anyvar.storage.base
    anyvar.storage.postgres
+   anyvar.storage.duckdb
+   anyvar.storage.snowflake
    anyvar.storage.mapper_registry
    anyvar.storage.mappers
    anyvar.storage.orm

--- a/docs/source/configuration/snowflake.rst
+++ b/docs/source/configuration/snowflake.rst
@@ -1,3 +1,5 @@
+.. _snowflake:
+
 Snowflake Data Warehouse Support
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/docs/source/configuration/storage.rst
+++ b/docs/source/configuration/storage.rst
@@ -4,7 +4,7 @@ Object Storage Configuration
 Storage Connection
 ==================
 
-Use the ``ANYVAR_STORAGE_URI`` environment variable to pass a `libpq connection string <https://www.postgresql.org/docs/current/libpq.html>`_ to the PostgreSQL connection constructor, or an empty string (``""``) to use :ref:`stateless mode <stateless_mode>`.
+AnyVar supports several different database engines. Use the ``ANYVAR_STORAGE_URI`` environment variable to designate the database engine and its location.
 
 .. list-table::
    :widths: 30 70
@@ -14,6 +14,13 @@ Use the ``ANYVAR_STORAGE_URI`` environment variable to pass a `libpq connection 
      - Default Value
    * - ``ANYVAR_STORAGE_URI``
      - ``"postgresql://postgres@localhost:5432/anyvar"``
+
+
+* A `libpq connection string <https://www.postgresql.org/docs/current/libpq.html>`_ constructs a PostgreSQL connection. This is the default database engine and is recommended for most use cases.
+* A URI with a ``snowflake://`` scheme constructs a Snowflake connection. See the :ref:`AnyVar Snowflake configuration <snowflake>` page for more information.
+* a URI with a ``duckdb://`` scheme constructs a `DuckDB <https://duckdb.org/>`_ connection. Use a relative file path, eg ``duckdb:///my_variants.duckdb``, for a file-based instance, or ``duckdb:///:memory:`` for an in-memory instance. See the :py:class:`~anyvar.storage.duckdb` API reference page for more information.
+* An empty string (ie ``export ANYVAR_STORAGE_URI=""``) enables :ref:`stateless mode <stateless_mode>`.
+
 
 
 Rename Tables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
+duckdb = ["duckdb-engine"]
 postgres = ["psycopg[binary]"]
 queueing = [
     "celery[redis]~=5.5.0",

--- a/src/anyvar/anyvar.py
+++ b/src/anyvar/anyvar.py
@@ -36,6 +36,7 @@ def create_storage(uri: str | None = None) -> Storage:
 
     * PostgreSQL: ``postgresql://[username]:[password]@[domain]/[database]``
     * Snowflake: ``snowflake://sf_username:@sf_account_identifier/sf_db_name/sf_schema_name?password=sf_password``
+    * DuckDB: ``duckdb:///:memory:` or ``duckdb:///relative/path/to/file``
 
     For no database (for testing or non-persistent use cases), use an empty string.
 
@@ -52,6 +53,10 @@ def create_storage(uri: str | None = None) -> Storage:
         from anyvar.storage.snowflake import SnowflakeObjectStore  # noqa: PLC0415
 
         storage = SnowflakeObjectStore(uri)
+    elif parsed_uri.scheme == "duckdb":
+        from anyvar.storage.duckdb import DuckDbObjectStore  # noqa: PLC0415
+
+        storage = DuckDbObjectStore(uri)
     elif parsed_uri.scheme == "":
         from anyvar.storage.no_db import NoObjectStore  # noqa: PLC0415
 

--- a/src/anyvar/storage/duckdb.py
+++ b/src/anyvar/storage/duckdb.py
@@ -1,0 +1,133 @@
+"""Provide DuckDB-based storage implementation.
+
+Most live, persistent variant registration and search services will want to employ the
+PostgreSQL storage option for its performance, particularly for concurrent writes and
+large-scale datasets. However, DuckDB may be better in certain use cases:
+
+* The DuckDB file-based option can be used to assemble a cohort or a dataset into a static
+  file, like an index, that can be easily passed along to other uses for later lookup This
+  option can also function as a simple registration service in cases where a
+  separately-provisioned PostgreSQL server is logistically prohibitive, although this is not ideal.
+* The DuckDB in-memory option can be used for simple testing and demonstration purposes,
+  and also works as a less-performant "stateless" translation service. Note that the
+  database is wiped and recreated every time a FastAPI service restarts.
+
+.. code-block:: pycon
+
+   >>> from anyvar.storage.duckdb import DuckDbObjectStore
+   >>> file_based = DuckDbObjectStore("duckdb:///path/to/my/variants.duckdb")
+   >>> in_memory = DuckDbObjectStore("duckdb:///:memory:")
+
+Under the hood, this should behave like a simpler but less-performant equivalent of
+Postgres. Our implementation is designed to employ common SqlAlchemy resources so there
+should be minimal specific maintenance required here.
+"""
+
+import json
+
+from pydantic import JsonValue
+from sqlalchemy import ColumnElement, create_engine, delete, func, select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from anyvar.storage import orm
+from anyvar.storage.sqlalchemy import SqlAlchemyStorage
+
+
+class DuckDbObjectStore(SqlAlchemyStorage):
+    """DuckDB-backed AnyVar object store."""
+
+    def __init__(self, db_uri: str, *args, **kwargs) -> None:
+        """Initialize PostgreSQL storage.
+
+        :param db_uri: DuckDB connection URI. See above for options.
+        """
+        self.db_url = db_uri
+        self.engine = create_engine(self.db_url, poolclass=StaticPool)
+        orm.Base.metadata.create_all(self.engine)
+        self.session_factory = sessionmaker(bind=self.engine)
+        self.batch_size = kwargs.get("batch_size", 1000)
+
+    def close(self) -> None:
+        """Close the storage backend."""
+        self.engine.dispose()
+
+    def wait_for_writes(self) -> None:
+        """Wait for all background writes to complete.
+        NOTE: This is a no-op for synchronous storage backends.
+        """
+
+    def wipe_db(self) -> None:
+        """Wipe all data from the storage backend."""
+        # Need a bunch of redundant sessions for DuckDB reasons that I don't totally get
+        with self.session_factory() as session, session.begin():
+            session.execute(delete(orm.VariationMapping))
+        with self.session_factory() as session, session.begin():
+            session.execute(delete(orm.Allele))
+        with self.session_factory() as session, session.begin():
+            session.execute(delete(orm.Location))
+        with self.session_factory() as session, session.begin():
+            session.execute(delete(orm.SequenceReference))
+
+            # Delete other tables
+            session.execute(delete(orm.VrsObject))
+            session.execute(delete(orm.Extension))
+
+    def _insert_ignore_conflict(
+        self, session: Session, orm_model: type[orm.Base], values: list[dict]
+    ) -> None:
+        """Perform an insert of the given values, ignoring ID conflicts
+
+        Should be implemented using specific engines/dialects of subclasses
+        """
+        stmt = insert(orm_model).on_conflict_do_nothing()
+        session.execute(stmt, values)
+
+    def _extension_delete_predicates(
+        self,
+        object_id: str,
+        name: str | None = None,
+        value: JsonValue | None = None,
+    ) -> list[ColumnElement[bool]]:
+        predicates = [orm.Extension.object_id == object_id]
+
+        if name is not None:
+            predicates.append(orm.Extension.name == name)
+
+            if value is not None:
+                predicates.append(orm.Extension.value == json.dumps(value))
+
+        return predicates
+
+    def delete_extensions(
+        self,
+        object_id: str,
+        name: str | None = None,
+        value: JsonValue | None = None,
+    ) -> int:
+        """Delete extension(s) for an object
+
+        Supports gradual specificity -- either delete all extensions,
+        or delete all extensions under a given key/name, or delete all extensions
+        with a given name AND value.
+
+        If no extension matching given args exists, do nothing.
+
+        Note that this gets a little slow in DuckDB, because we have to manually query
+        the # of matching rows first.
+
+        :param object_id: The object ID
+        :param name: Optional extension key/name to delete
+        :param value: Optional extension value to delete. Ignored if ``name`` is not provided
+        :return: Number of deleted rows
+        """
+        predicates = self._extension_delete_predicates(object_id, name, value)
+
+        count_stmt = select(func.count()).select_from(orm.Extension).where(*predicates)
+        delete_stmt = delete(orm.Extension).where(*predicates)
+
+        with self.session_factory() as session, session.begin():
+            deleted_count = session.scalar(count_stmt) or 0
+            session.execute(delete_stmt)
+            return deleted_count

--- a/src/anyvar/storage/orm.py
+++ b/src/anyvar/storage/orm.py
@@ -13,12 +13,11 @@ from sqlalchemy import (
     Dialect,
     Enum,
     ForeignKey,
-    Index,
     Integer,
+    Sequence,
     String,
     UniqueConstraint,
     create_engine,
-    func,
     inspect,
 )
 from sqlalchemy.dialects.postgresql import JSONB
@@ -176,22 +175,6 @@ class Location(Base):
         yield self
         yield self.sequence_reference
 
-    @declared_attr.directive
-    @classmethod
-    def __table_args__(cls):  # noqa: ANN206
-        uri = os.environ.get("ANYVAR_STORAGE_URI", DEFAULT_STORAGE_URI)
-        parsed_uri = urlparse(uri)
-        if parsed_uri.scheme == "snowflake":
-            return ()
-        return (
-            Index(
-                "ix_location_ref_overlap",
-                cls.sequence_reference_id,
-                func.int8range(cls.start, cls.end, "[]"),
-                postgresql_using="gist",
-            ),
-        )
-
 
 class Allele(Base):
     """AnyVar ORM model for Alleles"""
@@ -214,29 +197,18 @@ class Allele(Base):
 class Extension(Base):
     """AnyVar ORM model for extensions table."""
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    id: Mapped[int] = mapped_column(
+        Integer,
+        Sequence("extensions_id_seq"),
+        primary_key=True,
+    )
     object_id: Mapped[str] = mapped_column(String)
     name: Mapped[str] = mapped_column(String)
     value: Mapped[dict] = mapped_column(
         JSON()
         .with_variant(JSONB, "postgresql")
-        .with_variant(SnowflakeVARIANT, "snowflake")
+        .with_variant(SnowflakeVARIANT, "snowflake"),
     )
-
-    @declared_attr.directive
-    @classmethod
-    def __table_args__(cls):  # noqa: ANN206
-        uri = os.environ.get("ANYVAR_STORAGE_URI", DEFAULT_STORAGE_URI)
-        parsed_uri = urlparse(uri)
-        if parsed_uri.scheme == "snowflake":
-            return ()
-        return (
-            Index(
-                "idx_extensions_object_id_name",
-                "object_id",
-                "name",
-            ),
-        )
 
 
 mapping_type_enum = Enum(
@@ -252,10 +224,9 @@ mapping_type_enum = Enum(
 class VariationMapping(Base):
     """AnyVar ORM model for variation-to-variation mapping"""
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    source_id: Mapped[str] = mapped_column(String)
-    dest_id: Mapped[str] = mapped_column(String)
-    mapping_type: Mapped[str] = mapped_column(mapping_type_enum)
+    source_id: Mapped[str] = mapped_column(String, primary_key=True)
+    dest_id: Mapped[str] = mapped_column(String, primary_key=True)
+    mapping_type: Mapped[str] = mapped_column(mapping_type_enum, primary_key=True)
 
     @declared_attr.directive
     @classmethod
@@ -264,21 +235,7 @@ class VariationMapping(Base):
         parsed_uri = urlparse(uri)
         if parsed_uri.scheme == "snowflake":
             return (UniqueConstraint("source_id", "dest_id", "mapping_type"),)
-        return (
-            Index("idx_mappings_source_id", "source_id"),
-            Index("idx_mappings_dest_id", "dest_id"),
-            Index("idx_mappings_source_id_type", "source_id", "mapping_type"),
-            UniqueConstraint("source_id", "dest_id", "mapping_type"),
-        )
-
-
-def create_tables(db_url: str) -> None:
-    """Create all tables in the database.
-
-    :param db_url: Database connection URL (e.g., postgresql://user:pass@host:port/db)
-    """
-    engine = create_engine(db_url)
-    Base.metadata.create_all(engine)
+        return ()
 
 
 def session_factory(db_url: str) -> sessionmaker:

--- a/src/anyvar/storage/postgres.py
+++ b/src/anyvar/storage/postgres.py
@@ -1,47 +1,25 @@
 """Provide PostgreSQL-based storage implementation."""
 
 import json
-import logging
-from collections import defaultdict
-from collections.abc import Iterable
 
-from ga4gh.vrs import models as vrs_models
 from pydantic import JsonValue
-from sqlalchemy import and_, create_engine, delete, func, or_, select
-from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import joinedload, sessionmaker
-
-from anyvar.core import metadata
-from anyvar.core import objects as anyvar_objects
-from anyvar.storage import orm
-from anyvar.storage.base import (
-    AlleleSearchPage,
-    DataIntegrityError,
-    IncompleteVrsObjectError,
-    InvalidSearchParamsError,
-    Storage,
+from sqlalchemy import (
+    ColumnElement,
+    Engine,
+    Index,
+    create_engine,
+    delete,
+    func,
 )
-from anyvar.storage.mapper_registry import mapper_registry
-from anyvar.storage.orm import create_tables
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import Session, sessionmaker
 
-_logger = logging.getLogger(__name__)
+from anyvar.storage import orm
+from anyvar.storage.sqlalchemy import SqlAlchemyStorage
 
 
-class PostgresObjectStore(Storage):
-    """PostgreSQL storage backend using dedicated ORM tables.
-
-    This implementation uses the new Allele, Location, and SequenceReference tables
-    with object mapping to convert between VRS models and database entities.
-    """
-
-    MAX_ROWS = 100
-
-    _VRS_OBJECT_INSERT_ORDER: list[str] = [  # noqa: RUF012
-        orm.SequenceReference.__name__,
-        orm.Location.__name__,
-        orm.Allele.__name__,
-    ]
+class PostgresObjectStore(SqlAlchemyStorage):
+    """PostgreSQL storage backend using dedicated ORM tables."""
 
     def __init__(self, db_url: str, *args, **kwargs) -> None:
         """Initialize PostgreSQL storage.
@@ -52,7 +30,42 @@ class PostgresObjectStore(Storage):
         self.engine = create_engine(db_url)
         self.session_factory = sessionmaker(bind=self.engine)
         self.batch_size = kwargs.get("batch_size", 1000)
-        create_tables(self.db_url)
+        self._initialize(self.engine)
+
+    def _initialize(self, engine: Engine) -> None:
+        """Initialize postgres
+
+        Ensure existence of tables, engine-specific indices, etc
+        """
+        orm.Base.metadata.create_all(bind=engine)
+        self._create_indices(engine)
+
+    def _create_indices(self, engine: Engine) -> None:
+        """Create postgres-specific indices"""
+        indices = [
+            Index(
+                "ix_location_ref_overlap",
+                orm.Location.sequence_reference_id,
+                func.int8range(
+                    orm.Location.start,
+                    orm.Location.end,
+                    "[]",
+                ),
+                postgresql_using="gist",
+            ),
+            Index(
+                "idx_extensions_object_id_name",
+                orm.Extension.object_id,
+                orm.Extension.name,
+            ),
+            Index(
+                "idx_mappings_dest_id",
+                orm.VariationMapping.dest_id,
+            ),
+        ]
+
+        for idx in indices:
+            idx.create(bind=engine, checkfirst=True)
 
     def close(self) -> None:
         """Close the storage backend."""
@@ -62,278 +75,31 @@ class PostgresObjectStore(Storage):
         NOTE: This is a no-op for synchronous storage backends.
         """
 
-    def wipe_db(self) -> None:
-        """Wipe all data from the storage backend."""
-        with self.session_factory() as session, session.begin():
-            # Delete all data from tables in dependency order
-            session.execute(delete(orm.VariationMapping))
-            session.execute(delete(orm.Allele))
-            session.execute(delete(orm.Location))
-            session.execute(delete(orm.SequenceReference))
-
-            # Delete other tables
-            session.execute(delete(orm.VrsObject))
-            session.execute(delete(orm.Extension))
-
-    def add_objects(self, objects: Iterable[anyvar_objects.SupportedVrsObject]) -> None:
-        """Add multiple VRS objects to storage using bulk inserts.
-
-        If an object ID conflicts with an existing object, skip it.
-
-        This method assumes that for VRS objects (e.g. `Allele`, `SequenceLocation`,
-        `SequenceReference`) the `.id` property is present and uses the correct
-        GA4GH identifier for that object. It also assumes that contained objects are
-        similarly properly identified and materialized in full, not just as an IRI reference.
-        An error is raised if these assumptions are violated, rolling back the entire
-        transaction.
-
-        :param objects: VRS objects to add to storage
-        :raise IncompleteVrsObjectError: if object is missing required properties or if
-            required properties aren't fully dereferenced
-        """
-        objects_list: list[anyvar_objects.SupportedVrsObject] = list(objects)
-        if not objects_list:
-            return
-
-        # Collect unique entities by ID to avoid duplicates
-        vrs_objects = defaultdict(dict[str, orm.Base])
-
-        # Process all objects and extract their components
-        for vrs_object in objects_list:
-            try:
-                db_entity = mapper_registry.to_db_entity(vrs_object)
-            except AttributeError as e:
-                raise IncompleteVrsObjectError from e
-
-            object_parts = db_entity.disassemble()
-            for entity_type, entity in object_parts.items():
-                vrs_objects[entity_type][entity.id] = entity  # type: ignore (all children of orm.Base have an `id`)
-
-        with self.session_factory() as session, session.begin():
-            # Use ON CONFLICT DO NOTHING to handle duplicates gracefully
-            # We should have already de-duplicated by ID above, but duplicates
-            # may already exist in the database.
-
-            for vrs_object_type in self._VRS_OBJECT_INSERT_ORDER:
-                objects_by_id = vrs_objects[vrs_object_type]
-                if objects_by_id:
-                    dicts = [entity.to_dict() for entity in objects_by_id.values()]
-                    orm_model = getattr(orm, vrs_object_type)
-                    stmt = insert(orm_model).on_conflict_do_nothing()
-                    session.execute(stmt, dicts)
-
-    def get_objects(
-        self,
-        object_type: type[anyvar_objects.SupportedVrsObject],
-        object_ids: Iterable[str],
-    ) -> Iterable[anyvar_objects.SupportedVrsObject]:
-        """Retrieve multiple VRS objects from storage by their IDs.
-
-        If no object matches a given ID, that ID is skipped
-
-        :param object_type: type of object to get
-        :param object_ids: IDs of objects to fetch
-        :return: iterable collection of VRS objects matching given IDs
-        """
-        object_ids_list = list(object_ids)
-        if not object_ids_list:
-            return []
-
-        results = []
-        with self.session_factory() as session:
-            if object_type is vrs_models.Allele:
-                # Get alleles with eager loading
-                stmt = (
-                    select(orm.Allele)
-                    .options(
-                        joinedload(orm.Allele.location).joinedload(
-                            orm.Location.sequence_reference
-                        )
-                    )
-                    .where(orm.Allele.id.in_(object_ids_list))
-                )
-                db_objects = session.scalars(stmt).all()
-            elif object_type is vrs_models.SequenceLocation:
-                # Get locations with eager loading
-                stmt = (
-                    select(orm.Location)
-                    .options(joinedload(orm.Location.sequence_reference))
-                    .where(orm.Location.id.in_(object_ids_list))
-                )
-                db_objects = session.scalars(stmt).all()
-            elif object_type is vrs_models.SequenceReference:
-                # Get sequence references
-                stmt = select(orm.SequenceReference).where(
-                    orm.SequenceReference.id.in_(object_ids_list)
-                )
-
-                db_objects = session.scalars(stmt).all()
-            else:
-                raise ValueError(f"Unsupported object type: {object_type}")
-
-            for db_object in db_objects:
-                vrs_object = mapper_registry.from_db_entity(db_object)
-                results.append(vrs_object)
-
-        return results
-
-    def delete_objects(
-        self,
-        object_type: type[anyvar_objects.SupportedVrsObject],
-        object_ids: Iterable[str],
+    def _insert_ignore_conflict(
+        self, session: Session, orm_model: type[orm.Base], values: list[dict]
     ) -> None:
-        """Delete all objects of a specific type from storage.
+        """Perform an insert of the given values, ignoring ID conflicts
 
-        * If no object matching a given ID is found, it's ignored.
-        * Deletes do not cascade.
-
-        :param object_type: type of objects to delete
-        :param object_ids: IDs of objects to delete
-        :raise DataIntegrityError: if attempting to delete an object which is
-            depended upon by another object
+        Should be implemented using specific engines/dialects of subclasses
         """
-        object_ids_list = list(object_ids)
+        stmt = insert(orm_model).on_conflict_do_nothing()
+        session.execute(stmt, values)
 
-        with self.session_factory() as session, session.begin():
-            if object_type is vrs_models.Allele:
-                stmt = delete(orm.Allele).where(orm.Allele.id.in_(object_ids_list))
-            elif object_type is vrs_models.SequenceLocation:
-                stmt = delete(orm.Location).where(orm.Location.id.in_(object_ids_list))
-            elif object_type is vrs_models.SequenceReference:
-                stmt = delete(orm.SequenceReference).where(
-                    orm.SequenceReference.id.in_(object_ids_list)
-                )
-            else:
-                raise ValueError(f"Unsupported object type: {object_type}")
-            try:
-                session.execute(stmt)
-            except IntegrityError as e:
-                _logger.exception(
-                    "Attempted deletion that violated a foreign key constraint"
-                )
-                raise DataIntegrityError from e
-
-    def add_mapping(self, mapping: metadata.VariationMapping) -> None:
-        """Add a mapping between two objects.
-
-        If the mapping instance already exists, do nothing.
-
-        Todo:
-        * Implement insert constraint/MissingVariationReferenceError in #286
-
-        :param mapping: mapping object
-        :raises ValueError: If source_id equals dest_id
-        :raise MissingVariationReferenceError: if source or destination IDs aren't present in DB
-
-        """
-        if mapping.source_id == mapping.dest_id:
-            msg = f"source_id cannot equal dest_id: {mapping.source_id}"
-            raise ValueError(msg)
-
-        stmt = (
-            insert(orm.VariationMapping)
-            .values(
-                [
-                    {
-                        "source_id": mapping.source_id,
-                        "dest_id": mapping.dest_id,
-                        "mapping_type": mapping.mapping_type,
-                    }
-                ]
-            )
-            .on_conflict_do_nothing()
-        )
-        try:
-            with self.session_factory() as session, session.begin():
-                session.execute(stmt)
-        except IntegrityError as e:
-            raise KeyError from e
-
-    def delete_mapping(self, mapping: metadata.VariationMapping) -> None:
-        """Delete a mapping between two objects.
-
-        * If no such mapping exists in the DB, does nothing.
-        * Deletes do not cascade.
-
-        :param mapping: mapping object
-        """
-        stmt = (
-            delete(orm.VariationMapping)
-            .where(orm.VariationMapping.source_id == mapping.source_id)
-            .where(orm.VariationMapping.dest_id == mapping.dest_id)
-            .where(orm.VariationMapping.mapping_type == mapping.mapping_type)
-        )
-        with self.session_factory() as session, session.begin():
-            session.execute(stmt)
-
-    def get_mappings(
+    def _overlaps_interval_predicate(
         self,
-        object_id: str,
-        as_source: bool,
-        mapping_type: metadata.VariationMappingType | None = None,
-    ) -> Iterable[metadata.VariationMapping]:
-        """Return an iterable of mappings
+        start: int,
+        stop: int,
+    ) -> ColumnElement[bool]:
+        """Return a PostgreSQL range-overlap predicate.
 
-        Optionally provide a type to filter results.
-
-        :param object_id: ID of object to get mappings for
-        :param as_source: If ``True``, object_id is treated as the source. If ``False``,
-            ``object_id`` is treated as the destination.
-        :param mapping_type: The type of mapping to retrieve (defaults to `None` to
-            retrieve all mappings for the source ID)
-        :return: iterable collection of mapping descriptors (empty if no matching mappings exist)
+        Uses PostgreSQL's native range types and overlap operator to enable
+        efficient interval searches via a GiST index.
         """
-        stmt = select(orm.VariationMapping).limit(self.MAX_ROWS)
-        if as_source:
-            stmt = stmt.where(orm.VariationMapping.source_id == object_id)
-        else:
-            stmt = stmt.where(orm.VariationMapping.dest_id == object_id)
-        if mapping_type:
-            stmt = stmt.where(orm.VariationMapping.mapping_type == mapping_type)
-        with self.session_factory() as session, session.begin():
-            mappings = session.scalars(stmt).all()
-            return [mapper_registry.from_db_entity(mapping) for mapping in mappings]
-
-    def add_extension(self, extension: metadata.Extension) -> None:
-        """Add an extension to the database.
-
-        Adding the same extension repeatedly creates redundant records.
-
-        Todo:
-        * Implement insert constraint/MissingVariationReferenceError in #286
-
-        :param extension: The extension to add
-        :raise MissingVariationReferenceError: if no object corresponding to the extension's object ID is present in DB
-
-        """
-        db_entity: orm.Extension = mapper_registry.to_db_entity(extension)
-        stmt = insert(orm.Extension).returning(orm.Extension.id)
-        with self.session_factory() as session, session.begin():
-            session.execute(stmt, db_entity.to_dict()).scalar_one()
-
-    def get_extensions(
-        self, object_id: str, extension_name: str | None = None
-    ) -> list[metadata.Extension]:
-        """Get all extensions for the specified object, optionally filtered by type.
-
-        :param object_id: The ID of the object to retrieve extensions for
-        :param extension_type: The type of extension to retrieve (defaults to `None` to retrieve all extensions for the object)
-        :return: A list of extensions
-        """
-        stmt = select(orm.Extension).where(orm.Extension.object_id == object_id)
-
-        if extension_name:
-            stmt = stmt.where(orm.Extension.name == extension_name)
-
-        stmt = stmt.limit(self.MAX_ROWS)
-
-        with self.session_factory() as session, session.begin():
-            db_extensions = session.execute(stmt).scalars().all()
-
-            return [
-                mapper_registry.from_db_entity(db_extension)
-                for db_extension in db_extensions
-            ]
+        return func.int8range(
+            orm.Location.start,
+            orm.Location.end,
+            "[]",
+        ).op("&&")(func.int8range(start, stop, "[]"))
 
     def delete_extensions(
         self,
@@ -362,82 +128,3 @@ class PostgresObjectStore(Storage):
         with self.session_factory() as session, session.begin():
             result = session.execute(stmt)
             return result.rowcount or 0
-
-    def search_alleles(
-        self,
-        refget_accession: str,
-        start: int,
-        stop: int,
-        page_size: int = 1000,
-        cursor: str | None = None,
-    ) -> AlleleSearchPage:
-        """Find all Alleles that are located within the specified interval.
-
-        The interval is the closed range [start, stop] on the sequence identified by
-        the RefGet SequenceReference accession (`SQ.*`). Both `start` and `stop` are
-        inclusive and represent inter-residue positions.
-
-        Uses keyset pagination, meaning that altering the page size while looping through
-        successive cursors will effectively nullify the search loop.
-
-        Currently, any variation which overlaps the queried region is returned.
-
-        Raises an error if
-        * `start` or `end` are negative
-        * `end` > `start`
-
-        Todo (see Issue #338):
-        * define alternate match modes (partial/full overlap/contained/etc)
-        * define behavior for LSE indels and for alternative types of state (RLEs)
-
-        :param refget_accession: refget accession (e.g. `"SQ.IW78mgV5Cqf6M24hy52hPjyyo5tCCd86"`)
-        :param start: Inclusive, inter-residue start position of the interval
-        :param stop: Inclusive, inter-residue end position of the interval
-        :param page_size: Max # of results to return
-        :param cursor: Opaque key indicating start location for query in pagination
-        :return: Results page including variants and a cursor for next result page, if available
-        :raise InvalidSearchParamsError: if above search param requirements are violated
-        """
-        if start < 0 or stop < 0 or start > stop:
-            raise InvalidSearchParamsError
-        seek_start: int | None = None
-        seek_id: str | None = None
-        if cursor:
-            seek_start, seek_id = self._decode_search_cursor(cursor)
-
-        with self.session_factory() as session:
-            stmt = (
-                select(orm.Allele)
-                .options(
-                    joinedload(orm.Allele.location).joinedload(
-                        orm.Location.sequence_reference
-                    )
-                )
-                .join(orm.Location)
-                .join(orm.SequenceReference)
-                .where(
-                    orm.SequenceReference.id == refget_accession,
-                    func.int8range(orm.Location.start, orm.Location.end, "[]").op("&&")(
-                        func.int8range(start, stop, "[]")
-                    ),
-                )
-                .order_by(orm.Location.start, orm.Allele.id)
-                .limit(page_size)
-            )
-
-            # seek predicate -- assumes ORDER BY location.start ASC, allele.id ASC
-            if seek_start is not None and seek_id is not None:
-                stmt = stmt.where(
-                    or_(
-                        orm.Location.start > seek_start,
-                        and_(orm.Location.start == seek_start, orm.Allele.id > seek_id),
-                    )
-                )
-
-            page_db = session.scalars(stmt).all()
-            items = [mapper_registry.from_db_entity(a) for a in page_db]
-            if not page_db:
-                return AlleleSearchPage(items=[], next_cursor=None)
-            last = page_db[-1]
-            next_cursor = self._encode_search_cursor(last.location.start, last.id)
-            return AlleleSearchPage(items=items, next_cursor=next_cursor)

--- a/src/anyvar/storage/sqlalchemy.py
+++ b/src/anyvar/storage/sqlalchemy.py
@@ -1,0 +1,449 @@
+"""Abstract SqlAlchemy storage class
+
+Any database with an active SQLAlchemy engine should be able to pull resources from this
+class with minimal additional implementation to achieve a fully functional AnyVar storage class
+"""
+
+import base64
+import json
+import logging
+from abc import abstractmethod
+from collections import defaultdict
+from collections.abc import Iterable
+
+from ga4gh.vrs import models as vrs_models
+from sqlalchemy import ColumnElement, and_, delete, or_, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, joinedload, sessionmaker
+
+from anyvar.core import metadata
+from anyvar.core import objects as anyvar_objects
+from anyvar.storage import orm
+from anyvar.storage.base import (
+    AlleleSearchPage,
+    DataIntegrityError,
+    IncompleteVrsObjectError,
+    InvalidSearchParamsError,
+    Storage,
+)
+from anyvar.storage.mapper_registry import mapper_registry
+
+_logger = logging.getLogger(__name__)
+
+
+class SqlAlchemyStorage(Storage):
+    """Abstract base class for interacting with storage backends."""
+
+    MAX_ROWS = 100
+
+    session_factory: sessionmaker[Session]
+
+    _VRS_OBJECT_INSERT_ORDER: list[str] = [  # noqa: RUF012
+        orm.SequenceReference.__name__,
+        orm.Location.__name__,
+        orm.Allele.__name__,
+    ]
+
+    def wipe_db(self) -> None:
+        """Wipe all data from the storage backend."""
+        with self.session_factory() as session, session.begin():
+            session.execute(delete(orm.VariationMapping))
+            session.execute(delete(orm.Allele))
+            session.execute(delete(orm.Location))
+            session.execute(delete(orm.SequenceReference))
+
+            # Delete other tables
+            session.execute(delete(orm.VrsObject))
+            session.execute(delete(orm.Extension))
+
+    @abstractmethod
+    def _insert_ignore_conflict(
+        self, session: Session, orm_model: type[orm.Base], values: list[dict]
+    ) -> None:
+        """Perform an insert of the given values sets, ignoring ID conflicts
+
+        Should be implemented using specific engines/dialects of subclasses
+
+        :param session:
+        :param orm_model:
+        :param values:
+        """
+
+    def add_objects(self, objects: Iterable[anyvar_objects.SupportedVrsObject]) -> None:
+        """Add multiple VRS objects to storage.
+
+        If an object ID conflicts with an existing object, skip it.
+
+        This method assumes that for VRS objects (e.g. `Allele`, `SequenceLocation`,
+        `SequenceReference`) the `.id` property is present and uses the correct
+        GA4GH identifier for that object. It also assumes that contained objects are
+        similarly properly identified and materialized in full, not just as an IRI reference.
+        An error is raised if these assumptions are violated, rolling back the entire
+        transaction.
+
+        :param objects: VRS objects to add to storage
+        :raise IncompleteVrsObjectError: if object is missing required properties or if
+            required properties aren't fully dereferenced
+        """
+        objects_list: list[anyvar_objects.SupportedVrsObject] = list(objects)
+        if not objects_list:
+            return
+
+        # Collect unique entities by ID to avoid duplicates
+        vrs_objects = defaultdict(dict[str, orm.Base])
+
+        # Process all objects and extract their components
+        for vrs_object in objects_list:
+            try:
+                db_entity = mapper_registry.to_db_entity(vrs_object)
+            except AttributeError as e:
+                raise IncompleteVrsObjectError from e
+
+            object_parts = db_entity.disassemble()
+            for entity_type, entity in object_parts.items():
+                vrs_objects[entity_type][entity.id] = entity  # type: ignore (all children of orm.Base have an `id`)
+
+        with self.session_factory() as session, session.begin():
+            # Use ON CONFLICT DO NOTHING to handle duplicates gracefully
+            # We should have already de-duplicated by ID above, but duplicates
+            # may already exist in the database.
+
+            for vrs_object_type in self._VRS_OBJECT_INSERT_ORDER:
+                objects_by_id = vrs_objects[vrs_object_type]
+                if objects_by_id:
+                    dicts = [entity.to_dict() for entity in objects_by_id.values()]
+                    orm_model = getattr(orm, vrs_object_type)
+                    self._insert_ignore_conflict(session, orm_model, dicts)
+
+    def get_objects(
+        self,
+        object_type: type[anyvar_objects.SupportedVrsObject],
+        object_ids: Iterable[str],
+    ) -> Iterable[anyvar_objects.SupportedVrsObject]:
+        """Retrieve multiple VRS objects from storage by their IDs.
+
+        If no object matches a given ID, that ID is skipped
+
+        :param object_type: type of object to get
+        :param object_ids: IDs of objects to fetch
+        :return: iterable collection of VRS objects matching given IDs
+        """
+        object_ids_list = list(object_ids)
+        if not object_ids_list:
+            return []
+
+        results = []
+        with self.session_factory() as session:
+            if object_type is vrs_models.Allele:
+                # Get alleles with eager loading
+                stmt = (
+                    select(orm.Allele)
+                    .options(
+                        joinedload(orm.Allele.location).joinedload(
+                            orm.Location.sequence_reference
+                        )
+                    )
+                    .where(orm.Allele.id.in_(object_ids_list))
+                )
+                db_objects = session.scalars(stmt).all()
+            elif object_type is vrs_models.SequenceLocation:
+                # Get locations with eager loading
+                stmt = (
+                    select(orm.Location)
+                    .options(joinedload(orm.Location.sequence_reference))
+                    .where(orm.Location.id.in_(object_ids_list))
+                )
+                db_objects = session.scalars(stmt).all()
+            elif object_type is vrs_models.SequenceReference:
+                # Get sequence references
+                stmt = select(orm.SequenceReference).where(
+                    orm.SequenceReference.id.in_(object_ids_list)
+                )
+
+                db_objects = session.scalars(stmt).all()
+            else:
+                raise ValueError(f"Unsupported object type: {object_type}")
+
+            for db_object in db_objects:
+                vrs_object = mapper_registry.from_db_entity(db_object)
+                results.append(vrs_object)
+
+        return results
+
+    def delete_objects(
+        self,
+        object_type: type[anyvar_objects.SupportedVrsObject],
+        object_ids: Iterable[str],
+    ) -> None:
+        """Delete all objects of a specific type from storage.
+
+        * If no object matching a given ID is found, it's ignored.
+        * Deletes do not cascade.
+
+        :param object_type: type of objects to delete
+        :param object_ids: IDs of objects to delete
+        :raise DataIntegrityError: if attempting to delete an object which is
+            depended upon by another object
+        """
+        object_ids_list = list(object_ids)
+
+        with self.session_factory() as session, session.begin():
+            if object_type is vrs_models.Allele:
+                stmt = delete(orm.Allele).where(orm.Allele.id.in_(object_ids_list))
+            elif object_type is vrs_models.SequenceLocation:
+                stmt = delete(orm.Location).where(orm.Location.id.in_(object_ids_list))
+            elif object_type is vrs_models.SequenceReference:
+                stmt = delete(orm.SequenceReference).where(
+                    orm.SequenceReference.id.in_(object_ids_list)
+                )
+            else:
+                raise ValueError(f"Unsupported object type: {object_type}")
+            try:
+                session.execute(stmt)
+            except IntegrityError as e:
+                _logger.exception(
+                    "Attempted deletion that violated a foreign key constraint"
+                )
+                raise DataIntegrityError from e
+
+    def add_mapping(self, mapping: metadata.VariationMapping) -> None:
+        """Add a mapping between two objects.
+
+        If the mapping instance already exists, do nothing.
+
+        Todo:
+        * Implement insert constraint/MissingVariationReferenceError in #286
+
+        :param mapping: mapping object
+        :raises ValueError: If source_id equals dest_id
+        :raise MissingVariationReferenceError: if source or destination IDs aren't present in DB
+
+        """
+        if mapping.source_id == mapping.dest_id:
+            msg = f"source_id cannot equal dest_id: {mapping.source_id}"
+            raise ValueError(msg)
+
+        values = [
+            {
+                "source_id": mapping.source_id,
+                "dest_id": mapping.dest_id,
+                "mapping_type": mapping.mapping_type,
+            }
+        ]
+        try:
+            with self.session_factory() as session, session.begin():
+                self._insert_ignore_conflict(session, orm.VariationMapping, values)
+        except IntegrityError as e:
+            raise KeyError from e
+
+    def delete_mapping(self, mapping: metadata.VariationMapping) -> None:
+        """Delete a mapping between two objects.
+
+        * If no such mapping exists in the DB, does nothing.
+        * Deletes do not cascade.
+
+        :param mapping: mapping object
+        """
+        stmt = (
+            delete(orm.VariationMapping)
+            .where(orm.VariationMapping.source_id == mapping.source_id)
+            .where(orm.VariationMapping.dest_id == mapping.dest_id)
+            .where(orm.VariationMapping.mapping_type == mapping.mapping_type)
+        )
+        with self.session_factory() as session, session.begin():
+            session.execute(stmt)
+
+    def get_mappings(
+        self,
+        object_id: str,
+        as_source: bool,
+        mapping_type: metadata.VariationMappingType | None = None,
+    ) -> Iterable[metadata.VariationMapping]:
+        """Return an iterable of mappings
+
+        Optionally provide a type to filter results.
+
+        :param object_id: ID of object to get mappings for
+        :param as_source: If ``True``, object_id is treated as the source. If ``False``,
+            ``object_id`` is treated as the destination.
+        :param mapping_type: The type of mapping to retrieve (defaults to `None` to
+            retrieve all mappings for the source ID)
+        :return: iterable collection of mapping descriptors (empty if no matching mappings exist)
+        """
+        stmt = select(orm.VariationMapping).limit(self.MAX_ROWS)
+        if as_source:
+            stmt = stmt.where(orm.VariationMapping.source_id == object_id)
+        else:
+            stmt = stmt.where(orm.VariationMapping.dest_id == object_id)
+        if mapping_type:
+            stmt = stmt.where(orm.VariationMapping.mapping_type == mapping_type)
+        with self.session_factory() as session, session.begin():
+            mappings = session.scalars(stmt).all()
+            return [mapper_registry.from_db_entity(mapping) for mapping in mappings]
+
+    def add_extension(self, extension: metadata.Extension) -> None:
+        """Add an extension to the database.
+
+        Adding the same extension repeatedly creates redundant records.
+
+        Todo:
+        * Implement insert constraint/MissingVariationReferenceError in #286
+
+        :param extension: The extension to add
+        :raise MissingVariationReferenceError: if no object corresponding to the extension's object ID is present in DB
+
+        """
+        db_entity: orm.Extension = mapper_registry.to_db_entity(extension)
+        with self.session_factory() as session, session.begin():
+            self._insert_ignore_conflict(session, orm.Extension, [db_entity.to_dict()])
+
+    def get_extensions(
+        self, object_id: str, extension_name: str | None = None
+    ) -> list[metadata.Extension]:
+        """Get all extensions for the specified object, optionally filtered by type.
+
+        :param object_id: The ID of the object to retrieve extensions for
+        :param extension_type: The type of extension to retrieve (defaults to `None` to retrieve all extensions for the object)
+        :return: A list of extensions
+        """
+        stmt = select(orm.Extension).where(orm.Extension.object_id == object_id)
+
+        if extension_name:
+            stmt = stmt.where(orm.Extension.name == extension_name)
+
+        stmt = stmt.limit(self.MAX_ROWS)
+
+        with self.session_factory() as session, session.begin():
+            db_extensions = session.execute(stmt).scalars().all()
+
+            return [
+                mapper_registry.from_db_entity(db_extension)
+                for db_extension in db_extensions
+            ]
+
+    @staticmethod
+    def _encode_search_cursor(start: int, allele_id: str) -> str:
+        """Create cursor for search
+
+        :param start: start value for next row
+        :param allele_id: ID for next row
+        :return: cursor to use to fetch next page
+        """
+        raw = json.dumps(
+            {"start": start, "id": allele_id}, separators=(",", ":")
+        ).encode()
+        return base64.urlsafe_b64encode(raw).decode()
+
+    @staticmethod
+    def _decode_search_cursor(cursor: str) -> tuple[int, str]:
+        """Decode cursor for getting next page during search
+
+        :param cursor: opaque key included with previous result
+        :return: start and ID values indicating the first row of the next page
+        """
+        raw = base64.urlsafe_b64decode(cursor.encode())
+        obj = json.loads(raw)
+        return int(obj["start"]), str(obj["id"])
+
+    def _overlaps_interval_predicate(
+        self, start: int, stop: int
+    ) -> ColumnElement[bool]:
+        """Return a SQL predicate selecting locations that overlap an interval
+
+        This helper encapsulates the interval-overlap logic used by allele search
+        queries. The default implementation uses a portable comparison-based
+        predicate that works across SQL backends:
+
+            location.start <= query_stop
+            AND
+            location.end >= query_start
+
+        Subclasses may override this method to take advantage of backend-specific
+        features. For example, PostgreSQL can use native range types and GiST
+        indexes to accelerate overlap searches.
+
+        :param start: Inclusive, inter-residue start position of the query interval
+        :param stop: Inclusive, inter-residue end position of the query interval
+        :return: SQLAlchemy boolean expression selecting overlapping locations
+        """
+        return and_(
+            orm.Location.start <= stop,
+            orm.Location.end >= start,
+        )
+
+    def search_alleles(
+        self,
+        refget_accession: str,
+        start: int,
+        stop: int,
+        page_size: int = 1000,
+        cursor: str | None = None,
+    ) -> AlleleSearchPage:
+        """Find all Alleles that are located within the specified interval.
+
+        The interval is the closed range [start, stop] on the sequence identified by
+        the RefGet SequenceReference accession (`SQ.*`). Both `start` and `stop` are
+        inclusive and represent inter-residue positions.
+
+        Uses keyset pagination, meaning that altering the page size while looping through
+        successive cursors will effectively nullify the search loop.
+
+        Currently, any variation which overlaps the queried region is returned.
+
+        Raises an error if
+        * `start` or `end` are negative
+        * `end` > `start`
+
+        Todo (see Issue #338):
+        * define alternate match modes (partial/full overlap/contained/etc)
+        * define behavior for LSE indels and for alternative types of state (RLEs)
+
+        :param refget_accession: refget accession (e.g. `"SQ.IW78mgV5Cqf6M24hy52hPjyyo5tCCd86"`)
+        :param start: Inclusive, inter-residue start position of the interval
+        :param stop: Inclusive, inter-residue end position of the interval
+        :param page_size: Max # of results to return
+        :param cursor: Opaque key indicating start location for query in pagination
+        :return: Results page including variants and a cursor for next result page, if available
+        :raise InvalidSearchParamsError: if above search param requirements are violated
+        """
+        if start < 0 or stop < 0 or start > stop:
+            raise InvalidSearchParamsError
+        seek_start: int | None = None
+        seek_id: str | None = None
+        if cursor:
+            seek_start, seek_id = self._decode_search_cursor(cursor)
+
+        with self.session_factory() as session:
+            stmt = (
+                select(orm.Allele)
+                .options(
+                    joinedload(orm.Allele.location).joinedload(
+                        orm.Location.sequence_reference
+                    )
+                )
+                .join(orm.Location)
+                .join(orm.SequenceReference)
+                .where(
+                    orm.SequenceReference.id == refget_accession,
+                    self._overlaps_interval_predicate(start, stop),
+                )
+                .order_by(orm.Location.start, orm.Allele.id)
+                .limit(page_size)
+            )
+
+            # seek predicate -- assumes ORDER BY location.start ASC, allele.id ASC
+            if seek_start is not None and seek_id is not None:
+                stmt = stmt.where(
+                    or_(
+                        orm.Location.start > seek_start,
+                        and_(orm.Location.start == seek_start, orm.Allele.id > seek_id),
+                    )
+                )
+
+            page_db = session.scalars(stmt).all()
+            items = [mapper_registry.from_db_entity(a) for a in page_db]
+            if not page_db:
+                return AlleleSearchPage(items=[], next_cursor=None)
+            last = page_db[-1]
+            next_cursor = self._encode_search_cursor(last.location.start, last.id)
+            return AlleleSearchPage(items=items, next_cursor=next_cursor)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ pytest_plugins = ("celery.contrib.pytest",)
 
 def pytest_runtest_setup(item):
     """Skip tests not compatible with the current test database backend"""
-    all_dbs = {"postgresql", "snowflake"}
+    all_dbs = {"postgresql", "snowflake", "duckdb"}
     supported_dbs = all_dbs.intersection(mark.name for mark in item.iter_markers())
     current_db = (
         os.environ.get(

--- a/tests/unit/storage/test_duckdb.py
+++ b/tests/unit/storage/test_duckdb.py
@@ -1,0 +1,101 @@
+import pytest
+from ga4gh.vrs import models
+
+from anyvar.storage.duckdb import DuckDbObjectStore
+
+from .storage_test_funcs import (
+    run_alleles_crud,
+    run_db_lifecycle,
+    run_extensions_crud,
+    run_incomplete_objects_error,
+    run_mappings_crud,
+    run_objects_raises_integrityerror,
+    run_search_alleles,
+    run_sequencelocations_crud,
+    run_sequencereferences_crud,
+)
+
+pytestmark = pytest.mark.duckdb
+
+
+@pytest.fixture
+def duckdb_uri() -> str:
+    return "duckdb:///:memory:"
+
+
+@pytest.fixture
+def duckdb_storage(duckdb_uri: str):
+    """Reset storage state after each test case"""
+    storage = DuckDbObjectStore(duckdb_uri)
+    yield storage
+    storage.wipe_db()
+
+
+@pytest.mark.ci_ok
+def test_db_lifecycle(duckdb_uri: str, validated_vrs_alleles: dict[str, models.Allele]):
+    # set up and populate DB
+    storage = DuckDbObjectStore(duckdb_uri)
+    run_db_lifecycle(storage, validated_vrs_alleles)
+
+
+@pytest.mark.ci_ok
+def test_alleles_crud(
+    duckdb_storage: DuckDbObjectStore,
+    focus_alleles: tuple[models.Allele, models.Allele, models.Allele],
+    validated_vrs_alleles: dict[str, models.Allele],
+):
+    run_alleles_crud(duckdb_storage, focus_alleles, validated_vrs_alleles)
+
+
+@pytest.mark.ci_ok
+def test_incomplete_objects_error(duckdb_storage: DuckDbObjectStore):
+    run_incomplete_objects_error(duckdb_storage)
+
+
+@pytest.mark.ci_ok
+def test_objects_raises_integrityerror(
+    duckdb_storage: DuckDbObjectStore,
+    focus_alleles: tuple[models.Allele, models.Allele, models.Allele],
+):
+    run_objects_raises_integrityerror(duckdb_storage, focus_alleles)
+
+
+@pytest.mark.ci_ok
+def test_sequencelocations_crud(
+    duckdb_storage: DuckDbObjectStore,
+    focus_alleles: tuple[models.Allele, models.Allele, models.Allele],
+    validated_vrs_alleles: dict[str, models.Allele],
+):
+    run_sequencelocations_crud(duckdb_storage, focus_alleles, validated_vrs_alleles)
+
+
+@pytest.mark.ci_ok
+def test_sequencereferences_crud(
+    duckdb_storage: DuckDbObjectStore,
+    focus_alleles: tuple[models.Allele, models.Allele, models.Allele],
+    validated_vrs_alleles: dict[str, models.Allele],
+):
+    run_sequencereferences_crud(duckdb_storage, focus_alleles, validated_vrs_alleles)
+
+
+@pytest.mark.ci_ok
+def test_mappings_crud(
+    duckdb_storage: DuckDbObjectStore,
+    validated_vrs_alleles: dict[str, models.Allele],
+):
+    run_mappings_crud(duckdb_storage, validated_vrs_alleles)
+
+
+@pytest.mark.ci_ok
+def test_extensions_crud(
+    duckdb_storage: DuckDbObjectStore,
+    focus_alleles: tuple[models.Allele, models.Allele, models.Allele],
+):
+    run_extensions_crud(duckdb_storage, focus_alleles)
+
+
+def test_search_alleles(
+    duckdb_storage: DuckDbObjectStore,
+    validated_vrs_alleles: dict[str, models.Allele],
+):
+    run_search_alleles(duckdb_storage, validated_vrs_alleles)


### PR DESCRIPTION
close #475 

* Refactor most of the Postgres class into a `SqlAlchemyBase` class, to be reused by both Postgres and DuckDB. There is a tiny amount of postgres-specific code to maintain but most basic schema alterations can happen in the sqlalchemy base class, hopefully.
* Alter schema for mappings so that it enforces against row-duplication instead of using an autoincrementing ID key. This does technically change behavior but I think it's fine -- duplicate inserts are just idempotent instead of creating redundant rows (and redundancy is probably actively bad in the case of a mapping, for example). I think I could revert this though.
* Add DuckDB storage implementation. As far as I can tell it... totally works?  And is pretty straightforward once we've done the above. Add basic docs about usage. There are tests, but as with Snowflake, you can't easily run tests for different SqlAlchemy engines in one test run because of insane global state things, so it mirrors the way you select for different DB engines. This might be worth investigating later.

## Questions

* How to run DuckDB in CI/CD? We could easily parametrize the tests by storage URI so they run for the intersection of postgres/duckdb and 3.11/3.12/3.13. Is that overkill? Could also just run the duckdb-specific unit tests in a separate run.
    * Answer: to be addressed in #482 