### PR TITLE
cicd: update precommit stuff

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -91,23 +91,13 @@ jobs:
 
   precommit_hooks:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        cmd:
-          - "end-of-file-fixer"
-          - "trailing-whitespace"
-          - "mixed-line-ending"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+      - uses: j178/prek-action@v1
         with:
-          python-version: 3.12
+          extra_args: '--all-files --skip "ruff-format" --skip "ruff-check"'
 
-      - uses: pre-commit/action@v3.0.1
-        with:
-          extra_args: ${{ matrix.cmd }} --all-files
   docs:
     runs-on: ubuntu-latest
     env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,29 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0  # pre-commit-hooks version
+    rev: v6.0.0  # pre-commit-hooks version
     hooks:
-      - id: check-added-large-files
-      - id: detect-private-key
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-        exclude: "^docs/source/_templates/.*\\.rst"
-      - id: check-merge-conflict
       - id: detect-aws-credentials
         args: [ --allow-missing-credentials ]
+  - repo: builtin
+    hooks:
+      - id: trailing-whitespace
+      - id: check-added-large-files
+        args: ['--maxkb=1500']
+      - id: check-case-conflict
+      - id: end-of-file-fixer
+        exclude: "^docs/source/_templates/.*\\.rst"
+      - id: fix-byte-order-marker
+      - id: check-json
+      - id: check-toml
+      - id: check-yaml
       - id: mixed-line-ending
         args: [ --fix=lf ]
+      - id: check-merge-conflict
+      - id: detect-private-key
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.8  # ruff version
     hooks:
       - id: ruff-format
-      - id: ruff
+      - id: ruff-check
         args: [ --fix, --exit-non-zero-on-fix ]
-minimum_pre_commit_version: 4.2.0
+minimum_prek_version: 0.2.23

--- a/docs/source/_templates/module_summary.rst
+++ b/docs/source/_templates/module_summary.rst
@@ -5,4 +5,3 @@
    :undoc-members:
    :special-members: __init__
    :exclude-members: model_fields, model_config
-

--- a/docs/source/_templates/module_summary_no_inherit.rst
+++ b/docs/source/_templates/module_summary_no_inherit.rst
@@ -6,4 +6,3 @@
    :undoc-members:
    :special-members: __init__
    :exclude-members: model_fields, model_config, metadata
-

--- a/docs/source/api/api/anyvar.anyvar.rst
+++ b/docs/source/api/api/anyvar.anyvar.rst
@@ -1,4 +1,4 @@
-﻿anyvar.anyvar
+anyvar.anyvar
 =============
 
 .. automodule:: anyvar.anyvar

--- a/docs/source/api/api/anyvar.core.metadata.rst
+++ b/docs/source/api/api/anyvar.core.metadata.rst
@@ -1,4 +1,4 @@
-﻿anyvar.core.metadata
+anyvar.core.metadata
 ====================
 
 .. automodule:: anyvar.core.metadata

--- a/docs/source/api/api/anyvar.core.objects.rst
+++ b/docs/source/api/api/anyvar.core.objects.rst
@@ -1,4 +1,4 @@
-﻿anyvar.core.objects
+anyvar.core.objects
 ===================
 
 .. automodule:: anyvar.core.objects

--- a/docs/source/api/api/mapping/anyvar.mapping.liftover.rst
+++ b/docs/source/api/api/mapping/anyvar.mapping.liftover.rst
@@ -1,4 +1,4 @@
-﻿anyvar.mapping.liftover
+anyvar.mapping.liftover
 =======================
 
 .. automodule:: anyvar.mapping.liftover

--- a/docs/source/api/api/queueing/anyvar.queueing.celery_worker.rst
+++ b/docs/source/api/api/queueing/anyvar.queueing.celery_worker.rst
@@ -1,4 +1,4 @@
-﻿anyvar.queueing.celery_worker
+anyvar.queueing.celery_worker
 =============================
 
 .. automodule:: anyvar.queueing.celery_worker

--- a/docs/source/api/api/storage/anyvar.storage.base.rst
+++ b/docs/source/api/api/storage/anyvar.storage.base.rst
@@ -1,4 +1,4 @@
-﻿anyvar.storage.base
+anyvar.storage.base
 ===================
 
 .. automodule:: anyvar.storage.base

--- a/docs/source/api/api/storage/anyvar.storage.duckdb.rst
+++ b/docs/source/api/api/storage/anyvar.storage.duckdb.rst
@@ -1,4 +1,4 @@
-﻿anyvar.storage.duckdb
+anyvar.storage.duckdb
 =====================
 
 .. automodule:: anyvar.storage.duckdb

--- a/docs/source/api/api/storage/anyvar.storage.mapper_registry.rst
+++ b/docs/source/api/api/storage/anyvar.storage.mapper_registry.rst
@@ -1,4 +1,4 @@
-﻿anyvar.storage.mapper_registry
+anyvar.storage.mapper_registry
 ==============================
 
 .. automodule:: anyvar.storage.mapper_registry

--- a/docs/source/api/api/storage/anyvar.storage.mappers.rst
+++ b/docs/source/api/api/storage/anyvar.storage.mappers.rst
@@ -1,4 +1,4 @@
-﻿anyvar.storage.mappers
+anyvar.storage.mappers
 ======================
 
 .. automodule:: anyvar.storage.mappers

--- a/docs/source/api/api/storage/anyvar.storage.no_db.rst
+++ b/docs/source/api/api/storage/anyvar.storage.no_db.rst
@@ -1,4 +1,4 @@
-﻿anyvar.storage.no_db
+anyvar.storage.no_db
 ====================
 
 .. automodule:: anyvar.storage.no_db

--- a/docs/source/api/api/storage/anyvar.storage.orm.rst
+++ b/docs/source/api/api/storage/anyvar.storage.orm.rst
@@ -1,4 +1,4 @@
-﻿anyvar.storage.orm
+anyvar.storage.orm
 ==================
 
 .. automodule:: anyvar.storage.orm

--- a/docs/source/api/api/storage/anyvar.storage.postgres.rst
+++ b/docs/source/api/api/storage/anyvar.storage.postgres.rst
@@ -1,4 +1,4 @@
-﻿anyvar.storage.postgres
+anyvar.storage.postgres
 =======================
 
 .. automodule:: anyvar.storage.postgres

--- a/docs/source/api/api/storage/anyvar.storage.snowflake.rst
+++ b/docs/source/api/api/storage/anyvar.storage.snowflake.rst
@@ -1,4 +1,4 @@
-﻿anyvar.storage.snowflake
+anyvar.storage.snowflake
 ========================
 
 .. automodule:: anyvar.storage.snowflake

--- a/docs/source/api/api/translate/anyvar.translate.base.rst
+++ b/docs/source/api/api/translate/anyvar.translate.base.rst
@@ -1,4 +1,4 @@
-﻿anyvar.translate.base
+anyvar.translate.base
 =====================
 
 .. automodule:: anyvar.translate.base

--- a/docs/source/api/api/translate/anyvar.translate.vrs_python.rst
+++ b/docs/source/api/api/translate/anyvar.translate.vrs_python.rst
@@ -1,4 +1,4 @@
-﻿anyvar.translate.vrs_python
+anyvar.translate.vrs_python
 ===========================
 
 .. automodule:: anyvar.translate.vrs_python

--- a/docs/source/api/api/vcf/anyvar.vcf.ingest.rst
+++ b/docs/source/api/api/vcf/anyvar.vcf.ingest.rst
@@ -1,4 +1,4 @@
-﻿anyvar.vcf.ingest
+anyvar.vcf.ingest
 =================
 
 .. automodule:: anyvar.vcf.ingest

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -12,7 +12,7 @@ Clone and enter the repo, use the ``devready`` Makefile target to set up a virtu
     cd anyvar
     make devready
     source venv/3.11/bin/activate
-    pre-commit install
+    prek install
 
 Testing
 =======

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,7 @@ test = [
 ]
 dev = [
     "ruff==0.12.8",
-    "pre-commit>=4.2.0",
-    "ipykernel",
+    "prek>=0.2.23",
 ]
 docs = [
     "sphinx==8.2.3",


### PR DESCRIPTION
* run a single precommit action instead of 3. Honestly this is the actual nice change here, less scrolling to see if something failed.
* use `prek` instead of `pre-commit`, it's a little faster which is nice for rote tasks like committing. 
* Add some other nice-to-have precommit checks

## Notice

You must run `prek install -f` after merging these changes and updating your environment