### PR TITLE
feat!: make `mapping_type` optional 

### DIFF
--- a/docs/source/usage/rest_api.rst
+++ b/docs/source/usage/rest_api.rst
@@ -69,7 +69,7 @@ The ``/search`` endpoint enables retrieval of all variants that overlap a provid
 Working With Mappings
 =====================
 
-To add a :ref:`mapping <mappings>` between previously-registered variation objects issue a ``PUT`` request to ``/variations/<vrs_id>/mappings``, where ``vrs_id`` is the ``source_id`` of the mapping object:
+To add a :ref:`mapping <mappings>` between previously-registered variation objects issue a ``PUT`` request to ``/object/<vrs_id>/mappings``, where ``vrs_id`` is the ``source_id`` of the mapping object:
 
 .. code-block:: pycon
 
@@ -85,12 +85,12 @@ To add a :ref:`mapping <mappings>` between previously-registered variation objec
    ...     json=payload
    ... )
 
-Mappings from an object can be retrieved via ``GET /variations/<vrs_id>/mappings/<mapping_type>``:
+Mappings from an object can be retrieved via ``GET /object/<vrs_id>/mappings?mapping_type=<mapping_type>``:
 
 .. code-block:: pycon
 
    >>> response = requests.get(
-   ...     f"http://localhost:8000/object/{genomic_id}/mappings/transcribe_to"
+   ...     f"http://localhost:8000/object/{genomic_id}/mappings?mapping_type=transcribe_to"
    ... )
    >>> response.json()
    {'mappings': [{'source_id': 'ga4gh:VA.Otc5ovrw906Ack087o1fhegB4jDRqCAe',
@@ -106,7 +106,7 @@ By default, when a GRCh37 or GRCh38 variant is registered, the lifted-over equiv
    >>> response = requests.put("http://localhost:8000/variation", json=payload)
    >>> registered_allele_id = response.json()["object_id"]
    >>> response = requests.get(
-   ...     f"http://localhost:8000/object/{registered_allele_id}/mappings/liftover_to"
+   ...     f"http://localhost:8000/object/{registered_allele_id}/mappings?mapping_type=liftover_to"
    ... )
    >>> response.json()
    {'mappings': [{'source_id': 'ga4gh:VA.K7akyz9PHB0wg8wBNVlWAAdvMbJUJJfU',

--- a/src/anyvar/anyvar.py
+++ b/src/anyvar/anyvar.py
@@ -305,7 +305,7 @@ class AnyVar:
     def get_object_mappings(
         self,
         object_id: str,
-        mapping_type: metadata.VariationMappingType,
+        mapping_type: metadata.VariationMappingType | None = None,
         as_source: bool = True,
     ) -> Iterable[metadata.VariationMapping]:
         """Get all variation mappings given source object ID and mapping type

--- a/src/anyvar/restapi/objects_router.py
+++ b/src/anyvar/restapi/objects_router.py
@@ -215,7 +215,7 @@ By default, retrieve mappings of any type. Use the `mapping_type` argument to sp
 
 
 @objects_router.get(
-    "/object/{vrs_id}/mappings/{mapping_type}",
+    "/object/{vrs_id}/mappings",
     response_model_exclude_none=True,
     summary="Retrieve mappings for a VRS Object",
     description=_get_mappings_description,
@@ -224,8 +224,8 @@ def get_object_mapping(
     request: Request,
     vrs_id: Annotated[StrictStr, Path(..., description="VRS ID for variation")],
     mapping_type: Annotated[
-        metadata.VariationMappingType, Path(..., description="Mapping type")
-    ],
+        metadata.VariationMappingType | None, Query(..., description="Mapping type")
+    ] = None,
     as_source: Annotated[
         bool,
         Query(

--- a/tests/integration/restapi/objects_router/test_mappings.py
+++ b/tests/integration/restapi/objects_router/test_mappings.py
@@ -7,8 +7,6 @@ import pytest
 from anyvar.core import metadata
 from anyvar.storage.base import Storage
 
-DEFAULT_MAPPING_TYPE = metadata.VariationMappingType.LIFTOVER_TO
-
 
 @pytest.fixture
 def preloaded_allele_pairs(preloaded_alleles: dict):
@@ -32,7 +30,7 @@ def stored_variation_mappings(storage: Storage, preloaded_allele_pairs: list):
             metadata.VariationMapping(
                 source_id=source_vrs_object["id"],
                 dest_id=dest_vrs_object["id"],
-                mapping_type=DEFAULT_MAPPING_TYPE,
+                mapping_type=metadata.VariationMappingType.LIFTOVER_TO.value,
             )
         )
 
@@ -68,7 +66,10 @@ def test_put_mapping_idempotency(restapi_client, preloaded_allele_pairs):
     source_vrs_object, dest_vrs_object = preloaded_allele_pairs[0]
     source_vrs_id = source_vrs_object["id"]
     dest_vrs_id = dest_vrs_object["id"]
-    payload = {"dest_id": dest_vrs_id, "mapping_type": DEFAULT_MAPPING_TYPE}
+    payload = {
+        "dest_id": dest_vrs_id,
+        "mapping_type": metadata.VariationMappingType.LIFTOVER_TO.value,
+    }
 
     # First request
     first_resp = restapi_client.put(f"/object/{source_vrs_id}/mappings", json=payload)
@@ -90,7 +91,10 @@ def test_put_mapping_same_source_and_dest(restapi_client, preloaded_allele_pairs
 
     resp = restapi_client.put(
         f"/object/{source_vrs_id}/mappings",
-        json={"dest_id": source_vrs_id, "mapping_type": DEFAULT_MAPPING_TYPE},
+        json={
+            "dest_id": source_vrs_id,
+            "mapping_type": metadata.VariationMappingType.LIFTOVER_TO.value,
+        },
     )
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
     assert (
@@ -106,7 +110,10 @@ def test_put_mapping_invalid_source(restapi_client, preloaded_allele_pairs):
 
     resp = restapi_client.put(
         "/object/ga4gh:VA.invalidsource/mappings",
-        json={"dest_id": source_vrs_id, "mapping_type": DEFAULT_MAPPING_TYPE},
+        json={
+            "dest_id": source_vrs_id,
+            "mapping_type": metadata.VariationMappingType.LIFTOVER_TO.value,
+        },
     )
     assert resp.status_code == HTTPStatus.NOT_FOUND
     assert resp.json() == {"detail": "VRS Object ga4gh:VA.invalidsource not found"}
@@ -119,7 +126,10 @@ def test_put_mapping_invalid_dest(restapi_client, preloaded_allele_pairs):
 
     resp = restapi_client.put(
         f"/object/{source_vrs_id}/mappings",
-        json={"dest_id": "ga4gh:VA.invaliddest", "mapping_type": DEFAULT_MAPPING_TYPE},
+        json={
+            "dest_id": "ga4gh:VA.invaliddest",
+            "mapping_type": metadata.VariationMappingType.LIFTOVER_TO.value,
+        },
     )
     assert resp.status_code == HTTPStatus.NOT_FOUND
     assert resp.json() == {"detail": "VRS Object ga4gh:VA.invaliddest not found"}
@@ -148,7 +158,8 @@ def test_get_mapping_valid_request_found(restapi_client, stored_variation_mappin
     source_vrs_id = source_vrs_obj["id"]
 
     resp = restapi_client.get(
-        f"/object/{source_vrs_id}/mappings/{DEFAULT_MAPPING_TYPE}"
+        f"/object/{source_vrs_id}/mappings",
+        params={"mapping_type": metadata.VariationMappingType.LIFTOVER_TO.value},
     )
     assert resp.status_code == HTTPStatus.OK
     assert resp.json() == {
@@ -156,14 +167,17 @@ def test_get_mapping_valid_request_found(restapi_client, stored_variation_mappin
             {
                 "source_id": source_vrs_id,
                 "dest_id": dest_vrs_obj["id"],
-                "mapping_type": DEFAULT_MAPPING_TYPE,
+                "mapping_type": metadata.VariationMappingType.LIFTOVER_TO,
             }
         ]
     }
 
     resp = restapi_client.get(
-        f"/object/{dest_vrs_obj['id']}/mappings/{DEFAULT_MAPPING_TYPE}",
-        params={"as_source": False},
+        f"/object/{dest_vrs_obj['id']}/mappings",
+        params={
+            "as_source": False,
+            "mapping_type": metadata.VariationMappingType.LIFTOVER_TO.value,
+        },
     )
     assert resp.status_code == HTTPStatus.OK
     assert resp.json() == {
@@ -171,7 +185,36 @@ def test_get_mapping_valid_request_found(restapi_client, stored_variation_mappin
             {
                 "source_id": source_vrs_id,
                 "dest_id": dest_vrs_obj["id"],
-                "mapping_type": DEFAULT_MAPPING_TYPE,
+                "mapping_type": metadata.VariationMappingType.LIFTOVER_TO.value,
+            }
+        ]
+    }
+
+    # expect no transcription mappings
+    resp = restapi_client.get(
+        f"/object/{dest_vrs_obj['id']}/mappings",
+        params={
+            "as_source": False,
+            "mapping_type": metadata.VariationMappingType.TRANSCRIBE_TO.value,
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json() == {"mappings": []}
+
+
+def test_get_mapping_type_optional(restapi_client, stored_variation_mappings):
+    """Test that mapping_type is optional"""
+    source_vrs_obj, dest_vrs_obj = stored_variation_mappings[0]
+    source_vrs_id = source_vrs_obj["id"]
+
+    resp = restapi_client.get(f"/object/{source_vrs_id}/mappings")
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json() == {
+        "mappings": [
+            {
+                "source_id": source_vrs_id,
+                "dest_id": dest_vrs_obj["id"],
+                "mapping_type": metadata.VariationMappingType.LIFTOVER_TO,
             }
         ]
     }
@@ -182,7 +225,10 @@ def test_get_mapping_valid_request_not_found(restapi_client, stored_variation_ma
     source_vrs_obj, _ = stored_variation_mappings[0]
     source_vrs_id = source_vrs_obj["id"]
 
-    resp = restapi_client.get(f"/object/{source_vrs_id}/mappings/transcribe_to")
+    resp = restapi_client.get(
+        f"/object/{source_vrs_id}/mappings",
+        params={"mapping_type": metadata.VariationMappingType.TRANSCRIBE_TO.value},
+    )
     assert resp.status_code == HTTPStatus.OK
     assert resp.json() == {"mappings": []}
 
@@ -190,7 +236,8 @@ def test_get_mapping_valid_request_not_found(restapi_client, stored_variation_ma
 def test_get_mapping_invalid_source(restapi_client):
     """Test when an invalid source VRS ID is provided for GET method"""
     resp = restapi_client.get(
-        f"/object/ga4gh.VA:invalidsource/mappings/{DEFAULT_MAPPING_TYPE}"
+        "/object/ga4gh.VA:invalidsource/mappings",
+        params={"mapping_type": metadata.VariationMappingType.LIFTOVER_TO.value},
     )
     assert resp.status_code == HTTPStatus.NOT_FOUND
     assert resp.json() == {"detail": "VRS Object ga4gh.VA:invalidsource not found"}
@@ -201,7 +248,10 @@ def test_get_mapping_invalid_mapping(restapi_client, stored_variation_mappings):
     source_vrs_obj, _ = stored_variation_mappings[0]
     source_vrs_id = source_vrs_obj["id"]
 
-    resp = restapi_client.get(f"/object/{source_vrs_id}/mappings/invalid_mapping_type")
+    resp = restapi_client.get(
+        f"/object/{source_vrs_id}/mappings",
+        params={"mapping_type": "invalid_mapping_type"},
+    )
     assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
     assert (
         resp.json()["detail"][0]["msg"]

--- a/tests/integration/restapi/variations_router/test_variation.py
+++ b/tests/integration/restapi/variations_router/test_variation.py
@@ -215,8 +215,8 @@ def test_delete_object_and_mappings(restapi_client: TestClient, alleles: dict):
     response = restapi_client.get(f"/object/{allele_id}")
     assert response.status_code == HTTPStatus.NOT_FOUND
     for request_path in (
-        f"/object/{allele_id}/mappings/liftover_to?as_source=true",
-        f"/object/{allele_id}/mappings/liftover_to?as_source=false",
+        f"/object/{allele_id}/mappings?mapping_type=liftover_to&as_source=true",
+        f"/object/{allele_id}/mappings?mapping_type=liftover_to&as_source=false",
         f"/object/{allele_id}/extensions/clinvar_somatic_classification",
     ):
         response = restapi_client.get(request_path)


### PR DESCRIPTION
close #462 

I think this was a mistake in how we designed the endpoints -- we want a way to retrieve all mappings, but a path param can't be optional. It also makes more sense to me that `mapping_type` would be like a filter on the `/mappings/` path rather than a subtype. 

So the new path looks like `GET /objects/<vrs_id>/mappings?mapping_type=liftover_to` or `GET /objects/<vrs_id>/mappings`

## Alternatives considered

* Rather than re-engineering this endpoint, just add a new, general `GET /objects/<vrs_id>/mappings` endpoint that retrieves all mappings. I went ahead with just changing the existing endpoint for the reasons above.