### PR TITLE
chore: misc cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ pythonpath = ["src"]
 markers = [
     "ci_ok: tests safe to run in CI",
     "postgresql: tests safe to run when test db is Postgres",
+    "duckdb: tests safe to run when test db is duckdb"
 ]
 
 [tool.coverage.run]

--- a/src/anyvar/restapi/categorical_variants_router.py
+++ b/src/anyvar/restapi/categorical_variants_router.py
@@ -54,7 +54,7 @@ _put_psq_example = cat_vrs.CategoricalVariant(
 
 _put_psq_body = Body(
     description="A protein sequence consequence categorical variant with an ID that references an external knowledgebase record.",
-    example=_put_psq_example,
+    examples=[_put_psq_example],
 )
 
 
@@ -124,7 +124,7 @@ _put_ca_example = cat_vrs.CategoricalVariant(
 
 _put_ca_body = Body(
     description="A canonical allele categorical variant with an ID that references an external knowledgebase record.",
-    example=_put_ca_example,
+    examples=[_put_ca_example],
 )
 
 _put_ca_description = """Register a Canonical Allele Categorical Variant.

--- a/src/anyvar/restapi/objects_router.py
+++ b/src/anyvar/restapi/objects_router.py
@@ -77,7 +77,7 @@ def add_object_extension(
         AddExtensionRequest,
         Body(
             description="Extension to associate with the variation",
-            example={"name": "source_dataset", "value": "gnomAD_v4.1"},
+            examples=[{"name": "source_dataset", "value": "gnomAD_v4.1"}],
         ),
     ],
 ) -> AddExtensionResponse:


### PR DESCRIPTION
noticed some warnings during test runs:

* `example` arg is deprecated in `fastapi.Body`
* unregistered pytest mark